### PR TITLE
refactor: optimize helperImageSrc generating

### DIFF
--- a/packages/griffith/src/contexts/Position/PositionProvider.js
+++ b/packages/griffith/src/contexts/Position/PositionProvider.js
@@ -74,8 +74,11 @@ export default class PositionProvider extends React.PureComponent {
     const canvas = document.createElement('canvas')
     canvas.width = width
     canvas.height = height
-    const helperImageSrc = canvas.toDataURL()
-    this.setState({helperImageSrc})
+    canvas.toBlob(blob => {
+      URL.revokeObjectURL(this.state.helperImageSrc)
+      const helperImageSrc = URL.createObjectURL(blob)
+      this.setState({helperImageSrc})
+    }, 'image/jpeg')
   }
 
   updateIsFullWidth = () => {


### PR DESCRIPTION
## Description

`toDataURL` is too long. Use `toBlob ` and `createObjectURL` instead.

Fixes # (issue)

## How Has This Been Tested?

- [x] `Layer` is ok

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
