### PR TITLE
build: add `build:watch` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "build:lib": "lerna run build --parallel --ignore example --ignore griffith-standalone",
     "build:standalone": "lerna run --scope griffith-standalone build",
     "build": "yarn build:lib && yarn build:standalone",
+    "build:watch": "lerna run build:watch --stream --parallel",
     "release": "yarn build && lerna publish",
     "start": "yarn workspace example run start"
   },

--- a/packages/griffith-hls/package.json
+++ b/packages/griffith-hls/package.json
@@ -14,7 +14,8 @@
   "sideEffects": false,
   "scripts": {
     "prebuild": "rm -rf esm cjs",
-    "build": "rollup -c ../../rollup.config.js"
+    "build": "rollup -c ../../rollup.config.js",
+    "build:watch": "yarn build -w"
   },
   "peerDependencies": {
     "react": ">=16.3.0 <17.0.0",

--- a/packages/griffith-message/package.json
+++ b/packages/griffith-message/package.json
@@ -16,6 +16,7 @@
   "sideEffects": false,
   "scripts": {
     "prebuild": "rm -rf esm cjs",
-    "build": "rollup -c ../../rollup.config.js"
+    "build": "rollup -c ../../rollup.config.js",
+    "build:watch": "yarn build -w"
   }
 }

--- a/packages/griffith-mp4/package.json
+++ b/packages/griffith-mp4/package.json
@@ -14,7 +14,8 @@
   "sideEffects": false,
   "scripts": {
     "prebuild": "rm -rf esm cjs",
-    "build": "rollup -c ../../rollup.config.js"
+    "build": "rollup -c ../../rollup.config.js",
+    "build:watch": "yarn build -w"
   },
   "devDependencies": {
     "read-chunk": "^3.0.0"

--- a/packages/griffith-utils/package.json
+++ b/packages/griffith-utils/package.json
@@ -14,6 +14,7 @@
   "sideEffects": false,
   "scripts": {
     "prebuild": "rm -rf esm cjs",
-    "build": "rollup -c ../../rollup.config.js"
+    "build": "rollup -c ../../rollup.config.js",
+    "build:watch": "yarn build -w"
   }
 }

--- a/packages/griffith/package.json
+++ b/packages/griffith/package.json
@@ -16,7 +16,8 @@
   "types": "index.d.ts",
   "scripts": {
     "prebuild": "rm -rf esm cjs",
-    "build": "rollup -c ../../rollup.config.js"
+    "build": "rollup -c ../../rollup.config.js",
+    "build:watch": "yarn build -w"
   },
   "peerDependencies": {
     "react": ">=16.3.0 <17.0.0",


### PR DESCRIPTION
也可以利用 exec 来添加，但需要额外的 filter（scope/ignore） —— 如 `lerna exec --parallel --stream --scope griffith* --ignore griffith-standalone -- yarn build -w`

不如 run 直观，并且 standalone 有必要可以加不同的 watch script。