### PR TITLE
fix: last GOP dont have audio track

### DIFF
--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -25,6 +25,12 @@ module.exports = env => {
           changeOrigin: true,
           secure: false,
         },
+        '/vzuu': {
+          target: 'https://vdn1.vzuu.com/',
+          pathRewrite: {'^/vzuu': ''},
+          changeOrigin: true,
+          secure: false,
+        },
       },
     },
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   ],
   "scripts": {
     "format": "prettier \"packages/**/*.{js,json,md}\" \"*.{js,json,md}\"",
+    "format:fix": "prettier --write \"packages/**/*.{js,json,md}\" \"*.{js,json,md}\"",
     "lint": "eslint 'packages/*/src/**/*.js' '*.js'",
     "test": "jest",
     "test:coverage": "jest --coverage",

--- a/packages/griffith-mp4/src/mp4/utils/getBufferStart.js
+++ b/packages/griffith-mp4/src/mp4/utils/getBufferStart.js
@@ -52,5 +52,11 @@ function getChunkSize(mp4BoxTree, offsetStart, type) {
     type === 'video' ? 'videoStco' : 'audioStco'
   )
 
+  // 如果最后一个 GOP 没有音频轨，BufferStart 需要按照视频轨来计算。
+  // If the last GOP dont have audio track, we should ignore the audio chunk size.
+  if (chunkIndex >= stcoBox.samples.length) {
+    return Number.MAX_SAFE_INTEGER
+  }
+
   return stcoBox.samples[chunkIndex].chunkOffset + sampleSize
 }

--- a/packages/griffith-mp4/src/mp4/utils/getFragmentPosition.js
+++ b/packages/griffith-mp4/src/mp4/utils/getFragmentPosition.js
@@ -6,8 +6,15 @@ export default function getFragmentPosition(
 ) {
   const videoSamplesEnd = videoSamples[videoSamples.length - 1].end
   const videoSamplesStart = videoSamples[0].start
-  const audioSamplesEnd = audioSamples[audioSamples.length - 1].end
-  const audioSamplesStart = audioSamples[0].start
+
+  // maybe the last GOP dont have audio track
+  // 最后一个 GOP 序列可能没有音频轨
+  let audioSamplesEnd = 0
+  let audioSamplesStart = Number.MAX_SAFE_INTEGER
+  if (audioSamples.length !== 0) {
+    audioSamplesEnd = audioSamples[audioSamples.length - 1].end
+    audioSamplesStart = audioSamples[0].start
+  }
 
   const fragmentEndPosition = isLastFragmentPosition
     ? ''

--- a/packages/griffith-mp4/src/mse/controller.js
+++ b/packages/griffith-mp4/src/mse/controller.js
@@ -144,13 +144,18 @@ export default class MSE {
         FMP4.mdat(videoTrackInfo)
       )
 
-      const audioRawData = concatTypedArray(
-        FMP4.moof(audioTrackInfo, audioBaseMediaDecodeTime),
-        FMP4.mdat(audioTrackInfo)
-      )
+      // maybe the last GOP dont have audio track
+      // 最后一个 GOP 序列可能没有音频轨
+      if (audioTrackInfo.samples.length !== 0) {
+        const audioRawData = concatTypedArray(
+          FMP4.moof(audioTrackInfo, audioBaseMediaDecodeTime),
+          FMP4.mdat(audioTrackInfo)
+        )
+        this.sourceBuffers.audio.appendBuffer(audioRawData)
+      }
 
       this.sourceBuffers.video.appendBuffer(videoRawData)
-      this.sourceBuffers.audio.appendBuffer(audioRawData)
+
       if (time) {
         this.needUpdateTime = true
       }


### PR DESCRIPTION
# fix: last GOP dont have audio track

## Description

if the last GOP dont have audio track, we dont need append audio sourcebuffer.

for now, if we append audio sourcebuffer, we will get this error. see https://github.com/zhihu/griffith/issues/45


## How Has This Been Tested?

- [x] this [video](http://www.zhihu.com/video/1082027886072008704) can play normal
- [x] the example video can play normal

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
