### PR TITLE
fix: empty audio track

### DIFF
--- a/packages/griffith-mp4/src/mp4/mp4Probe.js
+++ b/packages/griffith-mp4/src/mp4/mp4Probe.js
@@ -69,6 +69,7 @@ export default class MP4Probe {
       videoSamples[videoSamples.length - 1].start +
         videoSamples[videoSamples.length - 1].bufferStart ===
       stcoBox.samples[stcoBox.samples.length - 1].chunkOffset
+
     return getFragmentPosition(
       videoSamples,
       audioSamples,

--- a/packages/griffith-mp4/src/mp4/utils/getSamplesInterval.js
+++ b/packages/griffith-mp4/src/mp4/utils/getSamplesInterval.js
@@ -11,6 +11,7 @@ export function getVideoSamplesInterval(mp4BoxTree, time = 0) {
   const timeInterval = intervalArray.map(interval =>
     getDuration(sttsBox, interval)
   )
+
   const interval = {
     offsetInterVal: [],
     timeInterVal: [],
@@ -52,8 +53,8 @@ export function getAudioSamplesInterval(mp4BoxTree, videoInterval) {
   let start = 0
   let end = 0
 
-  const {mediaTime} = audioElstBox.entries[0]
-  let startDuration = mediaTime || 0
+  const {mediaTime, segmentDuration} = audioElstBox.entries[0]
+  let startDuration = mediaTime !== -1 ? mediaTime : segmentDuration
   let endDuration = 0
   for (let i = 0; i < sttsBox.samples.length; i++) {
     const {sampleCount, sampleDelta} = sttsBox.samples[i]

--- a/packages/griffith-mp4/src/mse/controller.js
+++ b/packages/griffith-mp4/src/mse/controller.js
@@ -118,7 +118,6 @@ export default class MSE {
 
   seek = time => {
     FragmentFetch.clear()
-
     const [start, end] = this.mp4Probe.getFragmentPosition(time)
     this.mseUpdating = true
 


### PR DESCRIPTION
# fix: empty audio track

## Description

In some case, we have empty edit media time, If we dont ignore the empty edit media time, we will have audio/video sync problem. see https://github.com/zhihu/griffith/issues/14 

![image](https://user-images.githubusercontent.com/11402392/55317465-25ace100-54a3-11e9-9b95-e793bbbaac54.png)

## How Has This Been Tested?

- [x] this [video](https://v.vzuu.com/video/1071344677634146304) can play normally
- [x] the example video can play normally

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
