### PR TITLE
fix: use xhr instead of the fetch api

### DIFF
--- a/example/fmp4/index.js
+++ b/example/fmp4/index.js
@@ -1,7 +1,6 @@
 /* eslint-disable import/named */
 import '@babel/polyfill'
 import 'raf/polyfill'
-import 'whatwg-fetch'
 import React from 'react'
 import ReactDOM from 'react-dom'
 import App from './App'

--- a/example/hls/index.js
+++ b/example/hls/index.js
@@ -1,7 +1,6 @@
 /* eslint-disable import/named */
 import '@babel/polyfill'
 import 'raf/polyfill'
-import 'whatwg-fetch'
 import React from 'react'
 import ReactDOM from 'react-dom'
 import App from './App'

--- a/example/inline/index.js
+++ b/example/inline/index.js
@@ -1,7 +1,6 @@
 /* eslint-disable import/named */
 import '@babel/polyfill'
 import 'raf/polyfill'
-import 'whatwg-fetch'
 import React from 'react'
 import ReactDOM from 'react-dom'
 import App from './App'

--- a/example/main/index.js
+++ b/example/main/index.js
@@ -1,7 +1,6 @@
 /* eslint-disable import/named */
 import '@babel/polyfill'
 import 'raf/polyfill'
-import 'whatwg-fetch'
 import React from 'react'
 import ReactDOM from 'react-dom'
 import App from './App'

--- a/example/mp4/index.js
+++ b/example/mp4/index.js
@@ -1,7 +1,6 @@
 /* eslint-disable import/named */
 import '@babel/polyfill'
 import 'raf/polyfill'
-import 'whatwg-fetch'
 import React from 'react'
 import ReactDOM from 'react-dom'
 import App from './App'

--- a/example/package.json
+++ b/example/package.json
@@ -14,8 +14,7 @@
     "raf": "^3.4.1",
     "react": "16.4.2",
     "react-dom": "16.4.2",
-    "react-hot-loader": "^4.3.12",
-    "whatwg-fetch": "^3.0.0"
+    "react-hot-loader": "^4.3.12"
   },
   "devDependencies": {
     "@zhihu/babel-preset": "^1.7.0",

--- a/packages/griffith-mp4/src/fetch.js
+++ b/packages/griffith-mp4/src/fetch.js
@@ -3,33 +3,39 @@ export default class FragmentFetch {
 
   constructor(url, start, end, callback) {
     this.start = start
-    this.controller = new AbortController()
     FragmentFetch.queue.push(this)
-    return fetch(url, {
-      headers: {
-        Range: `bytes=${start}-${end}`,
-      },
-      signal: this.controller.signal,
-    })
-      .then(res => {
-        callback(res.arrayBuffer())
-        this.remove()
-      })
-      .catch(() => {
-        this.remove()
-      })
+
+    const xhr = new XMLHttpRequest()
+    this.xhr = xhr
+    xhr.open('get', url)
+    xhr.responseType = 'arraybuffer'
+    xhr.setRequestHeader('Range', `bytes=${start}-${end}`)
+    xhr.onload = () => {
+      if (xhr.status === 200 || xhr.status === 206) {
+        callback(xhr.response)
+      }
+      this.remove()
+    }
+    xhr.send()
+
+    xhr.onerror = () => {
+      this.remove()
+    }
+    xhr.onabort = () => {
+      this.remove()
+    }
   }
 
   remove = () => {
     FragmentFetch.queue = FragmentFetch.queue.filter(
-      item => item.start !== this.statr
+      item => item.start !== this.start
     )
   }
 
   static clear() {
     while (FragmentFetch.queue.length) {
       const item = FragmentFetch.queue.shift()
-      item.controller.abort()
+      item.xhr.abort()
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10366,7 +10366,7 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
   dependencies:
     iconv-lite "0.4.24"
 
-whatwg-fetch@>=0.10.0, whatwg-fetch@^3.0.0:
+whatwg-fetch@>=0.10.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
   integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==


### PR DESCRIPTION
# fix: use xhr instead of the fetch api

## Description

```AbortController``` only support Chrome 66+, so we use xhr instead of the fetch api.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
