### PR TITLE
fix: replay case

### DIFF
--- a/packages/griffith-mp4/src/mse/controller.js
+++ b/packages/griffith-mp4/src/mse/controller.js
@@ -151,6 +151,8 @@ export default class MSE {
       return
     }
 
+    this.handleReplayCase()
+
     this.loadData(start, end).then(mdatBuffer => {
       if (!mdatBuffer) {
         return
@@ -200,7 +202,8 @@ export default class MSE {
       videoInterval: {offsetInterVal = []} = [],
       mp4Data: {videoSamplesLength},
     } = this.mp4Probe
-    if (this.mediaSource.readyState === 'open') {
+
+    if (this.mediaSource.readyState !== 'closed') {
       if (offsetInterVal[1] === videoSamplesLength && !this.mseUpdating) {
         this.destroy()
       } else if (this.shouldFetchNextSegment()) {
@@ -209,7 +212,15 @@ export default class MSE {
     }
   }
 
+  handleReplayCase = () => {
+    if (this.mediaSource.readyState === 'ended') {
+      this.sourceBuffers.video.appendBuffer(new Uint8Array(0))
+    }
+  }
+
   shouldFetchNextSegment = () => {
+    this.handleReplayCase()
+
     if (!this.mseUpdating && this.mp4Probe.isDraining(this.video.currentTime)) {
       return true
     }

--- a/packages/griffith-mp4/src/player.js
+++ b/packages/griffith-mp4/src/player.js
@@ -43,8 +43,8 @@ export default class Player extends Component {
   }
 
   handlePlay = e => {
-    const {currentTime, buffered = []} = this.video
-    if (currentTime === 0 && !buffered.length) {
+    const {currentTime} = this.video
+    if (currentTime === 0) {
       this.mse.seek(0)
     }
 


### PR DESCRIPTION
# fix: replay case

## Description

the media source read state is ended when we click replay button, so we cannot append new buffer to media source.

the solution is we append a empty buffer to sourcebuffer before we try click replay button or move the slider. then the media source read state will reopen. 
see https://github.com/servo/servo/blob/master/tests/wpt/web-platform-tests/media-source/mediasource-append-buffer.html#L144


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
