### PR TITLE
fix: cannot read property hdlr of undefined

### DIFF
--- a/packages/griffith-mp4/src/mp4/mp4Box.js
+++ b/packages/griffith-mp4/src/mp4/mp4Box.js
@@ -59,7 +59,7 @@ export default class MP4Box {
       Box.readType(stream)
       Box.readBody(stream)
 
-      if (Box.type === 'trak') {
+      if (Box.type === 'trak' && Box.box.mdia) {
         const handlerType = Box.box.mdia.hdlr.handlerType
         if (handlerType === 'vide') {
           this.box.videoTrak = Box.box


### PR DESCRIPTION
# fix: cannot read property hdlr of undefined

## Description

In some case, the hdlr box is not the first sub box of trak box.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] this [video](https://v.vzuu.com/video/1082254812858601472?useMSE=true) can play normaly

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules