### PR TITLE
fix: failed to execute endOfStream on MediaSource

### DIFF
--- a/packages/griffith-mp4/src/mse/controller.js
+++ b/packages/griffith-mp4/src/mse/controller.js
@@ -261,7 +261,11 @@ export default class MSE {
   destroy = () => {
     this.mediaSource.removeEventListener('sourceopen', this.handleSourceOpen)
     URL.revokeObjectURL(this.video.src)
-    if (this.mediaSource.readyState === 'open') {
+    if (
+      this.mediaSource.readyState === 'open' &&
+      !this.sourceBuffers.video.updating &&
+      !this.sourceBuffers.audio.updating
+    ) {
       this.mediaSource.endOfStream()
     }
   }


### PR DESCRIPTION
# fix: failed to execute endOfStream on MediaSource

## Description

- Fix `Failed to execute 'endOfStream' on 'MediaSource': The 'updating' attribute is true on one or more of this MediaSource's SourceBuffers.`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
