### PR TITLE
fix: failed to execute start on TimeRanges

### DIFF
--- a/packages/griffith-mp4/src/mse/controller.js
+++ b/packages/griffith-mp4/src/mse/controller.js
@@ -140,7 +140,7 @@ export default class MSE {
     const time = isSeek ? this.video.currentTime : Math.floor((start + end) / 2)
     const buffered = this.video.buffered
 
-    if (buffered) {
+    if (buffered && buffered.length > 0) {
       for (let i = 0; i < buffered.length; i++) {
         if (time >= buffered.start(i) && time <= buffered.end(i)) {
           return true
@@ -213,7 +213,9 @@ export default class MSE {
       const track = this.sourceBuffers[key]
       const length = track.buffered.length
 
-      track.remove(track.buffered.start(0), track.buffered.end(length - 1))
+      if (length > 0) {
+        track.remove(track.buffered.start(0), track.buffered.end(length - 1))
+      }
     }
   }
 

--- a/packages/griffith-mp4/src/player.js
+++ b/packages/griffith-mp4/src/player.js
@@ -29,7 +29,7 @@ export default class Player extends Component {
     const currentTime = this.video.currentTime
     const buffered = this.video.buffered
 
-    if (isSafari) {
+    if (isSafari && buffered && buffered.length > 0) {
       if (currentTime - 0.1 > buffered.start(0)) {
         this.mse.seek(this.video.currentTime)
       } else if (currentTime < buffered.start(0)) {
@@ -57,7 +57,12 @@ export default class Player extends Component {
   handleVideoProgress = e => {
     const buffered = this.video.buffered
     const currentTime = this.video.currentTime
-    if (isSafari && buffered.length > 0 && currentTime < buffered.start(0)) {
+    if (
+      isSafari &&
+      buffered &&
+      buffered.length > 0 &&
+      currentTime < buffered.start(0)
+    ) {
       this.handleVideoSeeking()
     }
     this.props.onProgress(e)


### PR DESCRIPTION
# fix: failed to execute start on TimeRanges

## Description

Use `buffered .start` when `buffered.length` is not empty

- Fix: `Failed to execute 'start' on 'TimeRanges': The index provided (0) is greater than or equal to the maximum bound (0)`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
