### PR TITLE
fix: dont show Controller component when first frame is not ready

### DIFF
--- a/packages/griffith/src/components/Player/Player.js
+++ b/packages/griffith/src/components/Player/Player.js
@@ -489,7 +489,8 @@ class Player extends Component {
                 {title}
               </div>
             )}
-            {isPlaying && (
+            {/*首帧已加载完成时展示 MinimalTimeline 组件*/}
+            {isPlaying && (!isLoading || currentTime !== 0) && (
               <div
                 className={css(
                   hiddenOrShownStyle.base,
@@ -506,35 +507,38 @@ class Player extends Component {
                 />
               </div>
             )}
-            <div
-              className={css(
-                styles.controller,
-                hiddenOrShownStyle.base,
-                showController
-                  ? hiddenOrShownStyle.shown
-                  : hiddenOrShownStyle.hidden
-              )}
-              onMouseEnter={this.handleControllerPointerEnter}
-              onMouseLeave={this.handleControllerPointerLeave}
-            >
-              <Controller
-                standalone={standalone}
-                isPlaying={isPlaying}
-                duration={duration}
-                currentTime={currentTime}
-                volume={volume}
-                buffered={bufferedTime}
-                isFullScreen={isFullScreen}
-                onDragStart={this.handleControllerDragStart}
-                onDragEnd={this.handleControllerDragEnd}
-                onPlay={this.handlePlay}
-                onPause={this.handlePause}
-                onSeek={this.handleSeek}
-                onVolumeChange={this.handleVideoVolumeChange}
-                onToggleFullScreen={this.handleToggleFullScreen}
-                show={showController}
-              />
-            </div>
+            {/*首帧已加载完成时展示 Controller 组件*/}
+            {isPlaybackStarted && (!isLoading || currentTime !== 0) && (
+              <div
+                className={css(
+                  styles.controller,
+                  hiddenOrShownStyle.base,
+                  showController
+                    ? hiddenOrShownStyle.shown
+                    : hiddenOrShownStyle.hidden
+                )}
+                onMouseEnter={this.handleControllerPointerEnter}
+                onMouseLeave={this.handleControllerPointerLeave}
+              >
+                <Controller
+                  standalone={standalone}
+                  isPlaying={isPlaying}
+                  duration={duration}
+                  currentTime={currentTime}
+                  volume={volume}
+                  buffered={bufferedTime}
+                  isFullScreen={isFullScreen}
+                  onDragStart={this.handleControllerDragStart}
+                  onDragEnd={this.handleControllerDragEnd}
+                  onPlay={this.handlePlay}
+                  onPause={this.handlePause}
+                  onSeek={this.handleSeek}
+                  onVolumeChange={this.handleVideoVolumeChange}
+                  onToggleFullScreen={this.handleToggleFullScreen}
+                  show={showController}
+                />
+              </div>
+            )}
           </div>
         )}
         {error && (


### PR DESCRIPTION
# fix: don't show Controller component when the first frame is not ready

## Description

If the user executes seek action when the fist frame is not ready, will throw some error.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules