### PR TITLE
Example Build

### DIFF
--- a/example/babel.config.js
+++ b/example/babel.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  presets: ['@zhihu/babel-preset/app'],
-  plugins: ['react-hot-loader/babel'],
-}

--- a/example/package.json
+++ b/example/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.0.0",
-    "@babel/runtime": "^7.1.5",
+    "@hot-loader/react-dom": "^16.8.6",
     "griffith": "^1.4.2",
     "query-string": "^6.3.0",
     "raf": "^3.4.1",
@@ -17,7 +17,6 @@
     "react-hot-loader": "^4.3.12"
   },
   "devDependencies": {
-    "@zhihu/babel-preset": "^1.7.0",
     "babel-loader": "^8.0.4",
     "html-webpack-plugin": "^3.2.0",
     "webpack": "^4.26.1",

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -15,6 +15,10 @@ module.exports = env => {
       mp4: './mp4/index.js',
     },
 
+    resolve: {
+      mainFields: ['source', 'browser', 'module', 'main'],
+    },
+
     devServer: {
       disableHostCheck: true,
       port: 8000,

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -16,6 +16,9 @@ module.exports = env => {
     },
 
     resolve: {
+      alias: {
+        'react-dom': '@hot-loader/react-dom',
+      },
       mainFields: ['source', 'browser', 'module', 'main'],
     },
 
@@ -50,16 +53,11 @@ module.exports = env => {
               loader: 'babel-loader',
               options: {
                 cacheDirectory: true,
-              },
-            },
-            {
-              exclude: /@babel\/runtime/,
-              loader: 'babel-loader',
-              options: {
-                cacheDirectory: true,
-                configFile: false,
-                presets: ['@zhihu/babel-preset/dependencies'],
-                compact: false,
+                presets: ['@babel/preset-env', '@babel/preset-react'],
+                plugins: [
+                  '@babel/plugin-proposal-class-properties',
+                  'react-hot-loader/babel',
+                ],
               },
             },
           ],

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "build": "yarn build:lib && yarn build:standalone",
     "build:watch": "lerna run build:watch --stream --parallel",
     "release": "yarn build && lerna publish",
-    "start": "npm run build:watch & yarn workspace example run start"
+    "start": "yarn workspace example run start"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",

--- a/packages/griffith-hls/package.json
+++ b/packages/griffith-hls/package.json
@@ -14,8 +14,7 @@
   "sideEffects": false,
   "scripts": {
     "prebuild": "rm -rf esm cjs",
-    "build": "rollup -c ../../rollup.config.js",
-    "build:watch": "yarn build -w"
+    "build": "rollup -c ../../rollup.config.js"
   },
   "peerDependencies": {
     "react": ">=16.3.0 <17.0.0",

--- a/packages/griffith-message/package.json
+++ b/packages/griffith-message/package.json
@@ -16,7 +16,6 @@
   "sideEffects": false,
   "scripts": {
     "prebuild": "rm -rf esm cjs",
-    "build": "rollup -c ../../rollup.config.js",
-    "build:watch": "yarn build -w"
+    "build": "rollup -c ../../rollup.config.js"
   }
 }

--- a/packages/griffith-mp4/package.json
+++ b/packages/griffith-mp4/package.json
@@ -14,8 +14,7 @@
   "sideEffects": false,
   "scripts": {
     "prebuild": "rm -rf esm cjs",
-    "build": "rollup -c ../../rollup.config.js",
-    "build:watch": "yarn build -w"
+    "build": "rollup -c ../../rollup.config.js"
   },
   "devDependencies": {
     "read-chunk": "^3.0.0"

--- a/packages/griffith-utils/package.json
+++ b/packages/griffith-utils/package.json
@@ -14,7 +14,6 @@
   "sideEffects": false,
   "scripts": {
     "prebuild": "rm -rf esm cjs",
-    "build": "rollup -c ../../rollup.config.js",
-    "build:watch": "yarn build -w"
+    "build": "rollup -c ../../rollup.config.js"
   }
 }

--- a/packages/griffith/package.json
+++ b/packages/griffith/package.json
@@ -16,8 +16,7 @@
   "types": "index.d.ts",
   "scripts": {
     "prebuild": "rm -rf esm cjs",
-    "build": "rollup -c ../../rollup.config.js",
-    "build:watch": "yarn build -w"
+    "build": "rollup -c ../../rollup.config.js"
   },
   "peerDependencies": {
     "react": ">=16.3.0 <17.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -264,7 +264,7 @@
     "@babel/helper-remap-async-to-generator" "^7.1.0"
     "@babel/plugin-syntax-async-generators" "^7.2.0"
 
-"@babel/plugin-proposal-class-properties@^7.2.1", "@babel/plugin-proposal-class-properties@^7.4.0":
+"@babel/plugin-proposal-class-properties@^7.4.0":
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.4.0.tgz#d70db61a2f1fd79de927eea91f6411c964e084b8"
   integrity sha512-t2ECPNOXsIeK1JxJNKmgbzQtoG27KIlVE61vTqX0DKR9E9sZlVVxWUtEW9D5FlZ8b8j7SBNCHY47GgPKCKlpPg==
@@ -309,13 +309,6 @@
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz#69e1f0db34c6f5a0cf7e2b3323bf159a76c8cb7f"
   integrity sha512-1ZrIRBv2t0GSlcwVoQ6VgSLpLgiN/FVQUzt9znxo7v2Ov4jJrs8RY8tv0wvDmFN3qIdMKWrmMMW6yZ0G19MfGg==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.0.0"
-
-"@babel/plugin-syntax-dynamic-import@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz#69c159ffaf4998122161ad8ebc5e6d1f55df8612"
-  integrity sha512-mVxuJ0YroI/h/tbFTPGZR8cv6ai+STMKNBq0f8hFxsxWjl94qqhsb+wXbpNMDPU3cfR1TIsVFzU3nXyZMqyK4w==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
@@ -555,16 +548,6 @@
   dependencies:
     regenerator-transform "^0.13.4"
 
-"@babel/plugin-transform-runtime@^7.2.0":
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.4.0.tgz#b4d8c925ed957471bc57e0b9da53408ebb1ed457"
-  integrity sha512-1uv2h9wnRj98XX3g0l4q+O3jFM6HfayKup7aIu4pnnlzGz0H+cYckGBC74FZIWJXJSXAmeJ9Yu5Gg2RQpS4hWg==
-  dependencies:
-    "@babel/helper-module-imports" "^7.0.0"
-    "@babel/helper-plugin-utils" "^7.0.0"
-    resolve "^1.8.1"
-    semver "^5.5.1"
-
 "@babel/plugin-transform-shorthand-properties@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz#6333aee2f8d6ee7e28615457298934a3b46198f0"
@@ -619,7 +602,7 @@
     core-js "^2.6.5"
     regenerator-runtime "^0.13.2"
 
-"@babel/preset-env@^7.2.0", "@babel/preset-env@^7.4.2":
+"@babel/preset-env@^7.4.2":
   version "7.4.2"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.4.2.tgz#2f5ba1de2daefa9dcca653848f96c7ce2e406676"
   integrity sha512-OEz6VOZaI9LW08CWVS3d9g/0jZA6YCn1gsKIy/fut7yZCJti5Lm1/Hi+uo/U+ODm7g4I6gULrCP+/+laT8xAsA==
@@ -687,13 +670,6 @@
   integrity sha512-7hGhzlcmg01CvH1EHdSPVXYX1aJ8KCEyz6I9xYIi/asDtzBPMyMhVibhM/K6g/5qnKBwjZtp10bNZIEFTRW1MA==
   dependencies:
     regenerator-runtime "^0.12.0"
-
-"@babel/runtime@^7.1.5":
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.0.tgz#d523416573f19aa12784639e631257c7fc58c0aa"
-  integrity sha512-/eftZ45kD0OfOFHAmN02WP6N1NVphY+lBf8c2Q/P9VW3tj+N5NlBBAWfqOLOl96YDGMqpIBO5O/hQNx4A/lAng==
-  dependencies:
-    regenerator-runtime "^0.13.2"
 
 "@babel/template@^7.0.0", "@babel/template@^7.1.0", "@babel/template@^7.2.2", "@babel/template@^7.4.0":
   version "7.4.0"
@@ -866,6 +842,16 @@
   integrity sha512-oTu185GufTYHjTXPHu6k6HL7iuASOvDOtQizZWRSxj0VXuoki6e0HzvGZsRsycDTOn04Q9hVu+PhF83IUwRpeg==
   dependencies:
     find-up "^2.1.0"
+
+"@hot-loader/react-dom@^16.8.6":
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/@hot-loader/react-dom/-/react-dom-16.8.6.tgz#7923ba27db1563a7cc48d4e0b2879a140df461ea"
+  integrity sha512-+JHIYh33FVglJYZAUtRjfT5qZoT2mueJGNzU5weS2CVw26BgbxGKSujlJhO85BaRbg8sqNWyW1hYBILgK3ZCgA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.13.6"
 
 "@jest/console@^24.6.0":
   version "24.6.0"
@@ -1913,19 +1899,6 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
-"@zhihu/babel-preset@^1.7.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@zhihu/babel-preset/-/babel-preset-1.7.0.tgz#b1198d439d5bfcb3c67fd8c1f821bcee89bf36e3"
-  integrity sha512-zDgpCKPm/9S4ccKsGLN7W3uz6xNEJlk/XUALXt8N+DOJOQmfC42fTZa5vi2SIrh9CuAEKoeyDI+4nJepYtMwNg==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.0.0"
-    "@babel/plugin-proposal-class-properties" "^7.2.1"
-    "@babel/plugin-syntax-dynamic-import" "^7.2.0"
-    "@babel/plugin-transform-runtime" "^7.2.0"
-    "@babel/preset-env" "^7.2.0"
-    "@babel/preset-react" "^7.0.0"
-    babel-plugin-dynamic-import-node "^2.2.0"
-
 JSONStream@^1.0.4, JSONStream@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
@@ -2323,13 +2296,6 @@ babel-loader@^8.0.4:
     loader-utils "^1.0.2"
     mkdirp "^0.5.1"
     util.promisify "^1.0.0"
-
-babel-plugin-dynamic-import-node@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.2.0.tgz#c0adfb07d95f4a4495e9aaac6ec386c4d7c2524e"
-  integrity sha512-fP899ELUnTaBcIzmrW7nniyqqdYWrWuJUyPWHxFa/c7r7hS6KC8FscNfLlBNIoPSc55kYMGEEKjPjJGCLbE1qA==
-  dependencies:
-    object.assign "^4.1.0"
 
 babel-plugin-istanbul@^5.1.0:
   version "5.1.1"
@@ -8872,7 +8838,7 @@ resolve@1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@^1.10.0, resolve@^1.3.2, resolve@^1.5.0, resolve@^1.8.1, resolve@^1.9.0:
+resolve@^1.10.0, resolve@^1.3.2, resolve@^1.5.0, resolve@^1.9.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.0.tgz#3bdaaeaf45cc07f375656dfd2e54ed0810b101ba"
   integrity sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==
@@ -9026,6 +8992,14 @@ scheduler@^0.13.4:
   version "0.13.4"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.4.tgz#8fef05e7a3580c76c0364d2df5e550e4c9140298"
   integrity sha512-cvSOlRPxOHs5dAhP9yiS/6IDmVAVxmk33f0CtTJRkmUWcb1Us+t7b1wqdzoC0REw2muC9V5f1L/w5R5uKGaepA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
+scheduler@^0.13.6:
+  version "0.13.6"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.6.tgz#466a4ec332467b31a91b9bf74e5347072e4cd889"
+  integrity sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
- webpack 改为直接使用 package.json 的 source 字段解析 src 中的文件。这样开发的过程中不需要再起一个 watch。而且如果 webpack 使用 rollup 构建的文件会导致 source map 丢失，debug 不方便。
- 去掉 @zhihu/babel-preset
