### PR TITLE
fix: end of stream when last GOP is played

### DIFF
--- a/packages/griffith-mp4/src/mse/controller.js
+++ b/packages/griffith-mp4/src/mse/controller.js
@@ -266,9 +266,13 @@ export default class MSE {
     const {
       videoInterval: {offsetInterVal = []} = [],
       mp4Data: {videoSamplesLength},
+      timeRange = [],
     } = this.mp4Probe
     if (this.mediaSource.readyState !== 'closed') {
-      if (offsetInterVal[1] === videoSamplesLength) {
+      if (
+        offsetInterVal[1] === videoSamplesLength &&
+        this.video.currentTime > timeRange[0]
+      ) {
         this.destroy()
       } else if (this.shouldFetchNextSegment()) {
         this.seek()


### PR DESCRIPTION
# fix: end of the stream when last GOP is played

## Description

if we end of steam when the last GOP is not playing, the video duration will be changed, and the last GOP will not play ever.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules