### PR TITLE
fix: make a fake GOP when video dont have B/P frame

### DIFF
--- a/packages/griffith-mp4/src/mp4/utils/__tests__/getSamplesInterval.spec.js
+++ b/packages/griffith-mp4/src/mp4/utils/__tests__/getSamplesInterval.spec.js
@@ -1,4 +1,5 @@
 import {
+  getIntervalArray,
   getVideoSamplesInterval,
   getAudioSamplesInterval,
   getNextVideoSamplesInterval,
@@ -41,5 +42,30 @@ describe('getSamplesInterval', () => {
       offsetInterVal: [56, 86],
       timeInterVal: [56056, 86086],
     })
+  })
+
+  it('should get the sample interval array when video has B/P frame', () => {
+    const mockStssBox = {
+      samples: [
+        {
+          sampleNumber: 1,
+        },
+        {
+          sampleNumber: 251,
+        },
+        {
+          sampleNumber: 501,
+        },
+      ],
+    }
+    expect(getIntervalArray(mockStssBox)).toEqual([0, 250, 500])
+  })
+
+  it('should get the sample interval array when video has B/P frame', () => {
+    const mockStszBox = {
+      samples: [],
+    }
+    mockStszBox.samples.length = 21
+    expect(getIntervalArray(undefined, mockStszBox)).toEqual([0, 5, 10, 15, 20])
   })
 })

--- a/packages/griffith-mp4/src/mp4/utils/getSamplesInterval.js
+++ b/packages/griffith-mp4/src/mp4/utils/getSamplesInterval.js
@@ -7,7 +7,7 @@ export function getVideoSamplesInterval(mp4BoxTree, time = 0) {
   const stszBox = findBox(mp4BoxTree, 'videoStsz')
   const duration = getDuration(sttsBox, stszBox.samples.length)
 
-  const intervalArray = stssBox.samples.map(sample => sample.sampleNumber - 1)
+  const intervalArray = getIntervalArray(stssBox, stszBox)
   const timeInterval = intervalArray.map(interval =>
     getDuration(sttsBox, interval)
   )
@@ -87,11 +87,12 @@ export function getAudioSamplesInterval(mp4BoxTree, videoInterval) {
 
 export function getNextVideoSamplesInterval(mp4BoxTree, sample) {
   const stssBox = cloneDeep(findBox(mp4BoxTree, 'videoStss'))
-  const intervalArray = stssBox.samples.map(sample => sample.sampleNumber - 1)
   const sttsBox = cloneDeep(findBox(mp4BoxTree, 'videoStts'))
   const stszBox = findBox(mp4BoxTree, 'videoStsz')
   const sampleCount = stszBox.samples.length
   const duration = getDuration(sttsBox, sampleCount)
+
+  const intervalArray = getIntervalArray(stssBox, stszBox)
 
   const timeInterval = intervalArray.map(interval =>
     getDuration(sttsBox, interval)
@@ -113,4 +114,18 @@ export function getNextVideoSamplesInterval(mp4BoxTree, sample) {
     }
   }
   return result
+}
+
+export function getIntervalArray(stssBox, stszBox) {
+  let intervalArray = []
+  if (stssBox) {
+    intervalArray = stssBox.samples.map(sample => sample.sampleNumber - 1)
+  } else {
+    // make a fake GOP when video dont have B/P frame
+    for (let i = 0; i <= Math.floor(stszBox.samples.length / 5); i++) {
+      intervalArray.push(i * 5)
+    }
+  }
+
+  return intervalArray
 }

--- a/packages/griffith-mp4/src/mp4/utils/index.js
+++ b/packages/griffith-mp4/src/mp4/utils/index.js
@@ -5,6 +5,7 @@ import getFragmentPosition from './getFragmentPosition'
 import getBufferStart from './getBufferStart'
 import {getVideoSamples, getAudioSamples} from './getSamples'
 import {
+  getIntervalArray,
   getAudioSamplesInterval,
   getVideoSamplesInterval,
   getNextVideoSamplesInterval,
@@ -15,6 +16,7 @@ import getDuration from './getDuration'
 export {
   findBox,
   getDuration,
+  getIntervalArray,
   getSamplesOffset,
   getPerChunkArray,
   getFragmentPosition,


### PR DESCRIPTION
# fix: make a fake GOP when video dont have B/P frame

## Description

some video don't have B/P frame, we should make a fake GOP, then we can play it with streaming
![image](https://user-images.githubusercontent.com/11402392/56483425-8062b700-64fc-11e9-8d23-b58e21903d9a.png)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] this [video](https://v.vzuu.com/video/1101879073529208832) can play normally

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
