### PR TITLE
fix: mobile muted

### DIFF
--- a/packages/griffith/src/components/Player/Player.js
+++ b/packages/griffith/src/components/Player/Player.js
@@ -402,7 +402,6 @@ class Player extends Component {
             onPlaying={this.handleVideoPlaying}
             onSeeking={this.handleVideoSeeking}
             onSeeked={this.handleVideoSeeked}
-            onVolumeChange={this.handleVideoVolumeChange}
             onProgress={this.handleVideoProgress}
             onEvent={onEvent}
             useMSE={useMSE}

--- a/packages/griffith/src/components/Video/Video.js
+++ b/packages/griffith/src/components/Video/Video.js
@@ -32,7 +32,6 @@ class Video extends Component {
     onPlaying: PropTypes.func,
     onSeeking: PropTypes.func,
     onSeeked: PropTypes.func,
-    onVolumeChange: PropTypes.func,
     onProgress: PropTypes.func,
     onError: PropTypes.func.isRequired,
     onEvent: PropTypes.func.isRequired,
@@ -92,7 +91,7 @@ class Video extends Component {
       }
     }
 
-    if (this.root.volume !== volume ** 2) {
+    if (this.root.volume !== volume ** 2 && !isMobile) {
       this.root.volume = volume ** 2
     }
   }
@@ -234,13 +233,6 @@ class Video extends Component {
     }
   }
 
-  handleVolumeChange = () => {
-    const {onVolumeChange} = this.props
-    if (onVolumeChange) {
-      onVolumeChange(this.root.muted ? 0 : Math.sqrt(this.root.volume))
-    }
-  }
-
   handleProgress = () => {
     const {onProgress} = this.props
     const buffered = this.root.buffered
@@ -321,7 +313,6 @@ class Video extends Component {
         onError={this.handleError}
         onDurationChange={this.handleDurationChange}
         onTimeUpdate={this.handleTimeUpdate}
-        onVolumeChange={this.handleVolumeChange}
         onProgress={this.handleProgress}
         onWaiting={this.handleWaiting}
         onPlaying={this.handlePlaying}


### PR DESCRIPTION
# fix: mobile muted

## Description

Mobile device use the browser's default video controls, we don't need to handle `onVolumeChange ` event

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Allow the mobile user to control video volume
