### PR TITLE
fix: time wrap

### DIFF
--- a/packages/griffith/src/components/Controller/styles.js
+++ b/packages/griffith/src/components/Controller/styles.js
@@ -59,6 +59,7 @@ export default StyleSheet.create({
   time: {
     padding: '0 0.5em',
     width: '100px',
+    whiteSpace: 'nowrap',
     textAlign: 'center',
     fontSize: '0.875em',
     lineHeight: 2.5,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10992364/96109153-f1780480-0f10-11eb-9def-516255af006b.png)

修复时间元素过长导致的换行问题