### PR TITLE
fix: 对修复之前ie问题添加ie判断

### DIFF
--- a/packages/griffith/src/components/Player/Player.js
+++ b/packages/griffith/src/components/Player/Player.js
@@ -15,6 +15,7 @@ import {MinimalTimeline} from '../Timeline'
 import getBufferedTime from '../../utils/getBufferedTime'
 import storage from '../../utils/storage'
 import Pip from '../../utils/pip'
+import isIE from '../../utils/isIE'
 import {ObjectFitContext} from '../../contexts/ObjectFit'
 
 import styles, {hiddenOrShownStyle} from './styles'
@@ -179,7 +180,7 @@ class Player extends Component {
             this.setState({isLoading: true})
           }
           // workaround a bug in IE about replaying a video.
-          if (this.state.currentTime !== 0) {
+          if (isIE && this.state.currentTime !== 0) {
             this.handleSeek(0)
           }
         } else {

--- a/packages/griffith/src/utils/isIE.js
+++ b/packages/griffith/src/utils/isIE.js
@@ -1,0 +1,5 @@
+const isIE =
+  navigator.userAgent.indexOf('compatible') > -1 &&
+  navigator.userAgent.indexOf('MSIE') > -1
+
+export default isIE


### PR DESCRIPTION
## Description

之前在未播放状态时对播放器执行 update_time 操作，为了修复 ie 一个问题对未播放状态时间重置为0， 造成虽然给未播放状态播放器设置了开始时间，但一直从头播放，为修复这个问题，对之前这个 bug 降级判断 ie 浏览器才执行归零操作，以确保chrome等主流浏览器没有问题

Fixes # (issue)

## How Has This Been Tested?

- [x] 完成自测

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
