### PR TITLE
refactor: prefer using native ResizeObserver

### DIFF
--- a/packages/griffith/package.json
+++ b/packages/griffith/package.json
@@ -25,7 +25,6 @@
   },
   "dependencies": {
     "aphrodite": "2.3.1",
-    "element-resize-event": "^3.0.3",
     "eventemitter3": "^3.1.0",
     "griffith-hls": "^1.11.0",
     "griffith-message": "^1.11.0",

--- a/packages/griffith/src/contexts/Position/PositionProvider.js
+++ b/packages/griffith/src/contexts/Position/PositionProvider.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import {css} from 'aphrodite/no-important'
 import {reduce} from 'griffith-utils'
-import elementResizeEvent from 'element-resize-event'
+import listenResize from '../../utils/listenResize'
 import PositionContext from './PositionContext'
 import styles from './styles'
 
@@ -24,7 +24,6 @@ export default class PositionProvider extends React.PureComponent {
     if (this.props.shouldObserveResize) {
       this.startObservingResize()
     }
-    this.triggerUpdateIsFullWidth()
     this.updateHelperImageSrc()
   }
 
@@ -54,14 +53,13 @@ export default class PositionProvider extends React.PureComponent {
   startObservingResize = () => {
     const root = this.ref.current
     if (root) {
-      elementResizeEvent(root, this.updateIsFullWidth)
+      this.unlistenResize_ = listenResize(root, this.updateIsFullWidth)
     }
   }
 
   stopObservingResize() {
-    const root = this.ref.current
-    if (root) {
-      elementResizeEvent.unbind(root)
+    if (this.unlistenResize_) {
+      this.unlistenResize_()
     }
   }
 

--- a/packages/griffith/src/utils/listenResize.js
+++ b/packages/griffith/src/utils/listenResize.js
@@ -1,0 +1,50 @@
+import debounce from 'lodash/debounce'
+
+const listenResizePolyfill = (target, callback) => {
+  const MutationObserver =
+    window.MutationObserver || window.WebKitMutationObserver
+  let lastRect
+  const handler = () => {
+    const rect = target.getBoundingClientRect()
+    const isChanged = !(
+      lastRect &&
+      ['left', 'top', 'width', 'height'].every(k => lastRect[k] === rect[k])
+    )
+    if (isChanged) {
+      lastRect = rect
+      callback(rect)
+    }
+  }
+  const debounceHandler = debounce(handler, 100)
+  const observer = new MutationObserver(debounceHandler)
+  observer.observe(target, {
+    attributes: true,
+    characterData: true,
+    childList: true,
+    subtree: true,
+  })
+  handler()
+  window.addEventListener('resize', handler)
+  return () => {
+    observer.disconnect()
+    window.removeEventListener('resize', handler)
+  }
+}
+
+const listenResizeNative = (target, callback) => {
+  const observer = new ResizeObserver(changes =>
+    callback(changes[0].contentRect)
+  )
+  observer.observe(target)
+  return () => {
+    observer.disconnect()
+  }
+}
+
+/** 监听元素大小改改 @see https://caniuse.com/#search=ResizeObserver */
+const listenResize =
+  typeof ResizeObserver === 'function'
+    ? listenResizeNative
+    : listenResizePolyfill
+
+export default listenResize

--- a/yarn.lock
+++ b/yarn.lock
@@ -5334,11 +5334,6 @@ elegant-spinner@^1.0.1:
   resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
   integrity sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=
 
-element-resize-event@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/element-resize-event/-/element-resize-event-3.0.3.tgz#3f59facef6b8f23fbd678a5f364ee5723af98a2a"
-  integrity sha512-vhGNxT87PdZA6Ak4E0QhArwGzNcSPUwSN7n9wCFLeBlY2NNuuiwguQuQIp7P5oB65PLJ892yKcHiqz1xLWeiug==
-
 elliptic@^6.0.0:
   version "6.5.4"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"


### PR DESCRIPTION
element-resize-event：
- 过时的库，当前已经不需要了（polyfill 其实也是多余的，相对于我们的覆盖范围，这个 PR 仍然加了是为了更好地兼容）
- 它内部有个非法模块格式使用 [exports.bind](https://github.com/KyleAMathews/element-resize-event/blob/master/index.js#L70)

看起来 resize 监听本身也可能是多余的，最好完全用 CSS 方案来替换。