### PR TITLE
chore: remove query-string

### DIFF
--- a/packages/griffith/package.json
+++ b/packages/griffith/package.json
@@ -32,8 +32,7 @@
     "griffith-utils": "^1.11.0",
     "isomorphic-bigscreen": "2.0.5",
     "lodash": "^4.17.15",
-    "prop-types": "^15.7.2",
-    "query-string": "^6.4.2"
+    "prop-types": "^15.7.2"
   },
   "devDependencies": {
     "jest-localstorage-mock": "^2.4.0"

--- a/packages/griffith/src/contexts/VideoSource/VideoSourceProvider.js
+++ b/packages/griffith/src/contexts/VideoSource/VideoSourceProvider.js
@@ -1,12 +1,16 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import {parse} from 'query-string'
 import VideoSourceContext from './VideoSourceContext'
 import {getQualities, getSources} from './parsePlaylist'
 import {EVENTS} from 'griffith-message'
 import {ua} from 'griffith-utils'
 
 const {isMobile} = ua
+
+const getQuery = (url, key) => {
+  const [, value] = url.match(new RegExp(`\\b${key}=([^&]+)`)) || []
+  return value
+}
 
 export default class VideoSourceProvider extends React.Component {
   static propTypes = {
@@ -31,7 +35,7 @@ export default class VideoSourceProvider extends React.Component {
   ) => {
     if (!videoSources) return null
     const {format, play_url} = Object.values(videoSources)[0]
-    const {expiration} = parse(play_url)
+    const expiration = getQuery(play_url, 'expiration')
     const dataKey = `${id}-${expiration}` // expiration 和 id 组合可以唯一标识一次请求的数据
 
     if (dataKey == state.dataKey) return null

--- a/yarn.lock
+++ b/yarn.lock
@@ -11764,15 +11764,6 @@ query-string@^5.0.1:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
-query-string@^6.4.2:
-  version "6.4.2"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.4.2.tgz#8be1dbd105306aebf86022144f575a29d516b713"
-  integrity sha512-DfJqAen17LfLA3rQ+H5S4uXphrF+ANU1lT2ijds4V/Tj4gZxA3gx5/tg1bz7kYCmwna7LyJNCYqO7jNRzo3aLw==
-  dependencies:
-    decode-uri-component "^0.2.0"
-    split-on-first "^1.0.0"
-    strict-uri-encode "^2.0.0"
-
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -13289,11 +13280,6 @@ spdy@^4.0.0:
     select-hose "^2.0.0"
     spdy-transport "^3.0.0"
 
-split-on-first@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.0.0.tgz#648af4ce9a28fbcaadd43274455f298b55025fc6"
-  integrity sha512-mjA57TQtdWztVZ9THAjGNpgbuIrNfsNrGa5IyK94NoPaT4N14M+GI4jD7t4arLjFkYRQWdETC5RxFzLWouoB3A==
-
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
@@ -13444,11 +13430,6 @@ strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
   integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
-
-strict-uri-encode@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
-  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-argv@^0.0.2:
   version "0.0.2"


### PR DESCRIPTION
节省几 K。

PS. 像旧的 history 会依赖它，但新版不会。建议使用标准化 URLSearchParams。

```js
├─┬ griffith@1.12.0
│ └── query-string@6.13.7 
├─┬ history@3.3.0
│ └── query-string@4.3.4  deduped
└── query-string@4.3.4 
```