### PR TITLE
feat: add SUBSCRIPTION_READY event

### DIFF
--- a/packages/griffith-message/README-zh-Hans.md
+++ b/packages/griffith-message/README-zh-Hans.md
@@ -62,27 +62,28 @@ dispatchMessage(targetWindow, messageName, data)
 
 从播放器接收到的事件
 
-| `messageName`                      | 说明                   | `data`                                           |
-| ---------------------------------- | ---------------------- | ------------------------------------------------ |
-| `EVENTS.DOM.PLAY`                  | 播放                   | 见下表                                           |
-| `EVENTS.DOM.PLAYING`               | 从暂停或缓冲中恢复播放 | 见下表                                           |
-| `EVENTS.DOM.PAUSE`                 | 暂停                   | 见下表                                           |
-| `EVENTS.DOM.ENDED`                 | 停止                   | 见下表                                           |
-| `EVENTS.DOM.TIMEUPDATE`            | 进度更新               | 见下表                                           |
-| `EVENTS.DOM.ERROR`                 | 错误                   | 见下表                                           |
-| `EVENTS.DOM.WAITING`               | 缓冲                   | 见下表                                           |
-| `EVENTS.PLAYER.REQUEST_PLAY`       | 用户触发播放           | 无                                               |
-| `EVENTS.PLAYER.QUALITY_CHANGE`     | 清晰度切换             | `{quality: string, prevQuality: string}`         |
-| `EVENTS.PLAYER.PLAY_COUNT`         | 播放一次               | 无                                               |
-| `EVENTS.PLAYER.PLAY_FAILED`        | 播放失败               | `{currentTime: number}`                          |
-| `EVENTS.PLAYER.ENTER_FULLSCREEN`   | 进入全屏               | 无                                               |
-| `EVENTS.PLAYER.EXIT_FULLSCREEN`    | 退出全屏               | 无                                               |
-| `EVENTS.PLAYER.ENTER_PIP`          | 进入画中画             | 无                                               |
-| `EVENTS.PLAYER.EXIT_PIP`           | 退出画中画             | 无                                               |
-| `EVENTS.PLAYER.SHOW_CONTROLLER`    | 显示播放器进度条控件   | 无                                               |
-| `EVENTS.PLAYER.HIDE_CONTROLLER`    | 隐藏播放器进度条控件   | 无                                               |
-| `EVENTS.PLAYER.HOVER_PROGRESS_DOT` | 鼠标 hover 播放节点    | `{startTime: number, left: number, top: number}` |
-| `EVENTS.PLAYER.LEAVE_PROGRESS_DOT` | 鼠标离开播放节点       | 无                                               |
+| `messageName`                      | 说明                               | `data`                                           |
+| ---------------------------------- | ---------------------------------- | ------------------------------------------------ |
+| `EVENTS.DOM.PLAY`                  | 播放                               | 见下表                                           |
+| `EVENTS.DOM.PLAYING`               | 从暂停或缓冲中恢复播放             | 见下表                                           |
+| `EVENTS.DOM.PAUSE`                 | 暂停                               | 见下表                                           |
+| `EVENTS.DOM.ENDED`                 | 停止                               | 见下表                                           |
+| `EVENTS.DOM.TIMEUPDATE`            | 进度更新                           | 见下表                                           |
+| `EVENTS.DOM.ERROR`                 | 错误                               | 见下表                                           |
+| `EVENTS.DOM.WAITING`               | 缓冲                               | 见下表                                           |
+| `EVENTS.PLAYER.REQUEST_PLAY`       | 用户触发播放                       | 无                                               |
+| `EVENTS.PLAYER.QUALITY_CHANGE`     | 清晰度切换                         | `{quality: string, prevQuality: string}`         |
+| `EVENTS.PLAYER.PLAY_COUNT`         | 播放一次                           | 无                                               |
+| `EVENTS.PLAYER.PLAY_FAILED`        | 播放失败                           | `{currentTime: number}`                          |
+| `EVENTS.PLAYER.ENTER_FULLSCREEN`   | 进入全屏                           | 无                                               |
+| `EVENTS.PLAYER.EXIT_FULLSCREEN`    | 退出全屏                           | 无                                               |
+| `EVENTS.PLAYER.ENTER_PIP`          | 进入画中画                         | 无                                               |
+| `EVENTS.PLAYER.EXIT_PIP`           | 退出画中画                         | 无                                               |
+| `EVENTS.PLAYER.SHOW_CONTROLLER`    | 显示播放器进度条控件               | 无                                               |
+| `EVENTS.PLAYER.HIDE_CONTROLLER`    | 隐藏播放器进度条控件               | 无                                               |
+| `EVENTS.PLAYER.HOVER_PROGRESS_DOT` | 鼠标 hover 播放节点                | `{startTime: number, left: number, top: number}` |
+| `EVENTS.PLAYER.LEAVE_PROGRESS_DOT` | 鼠标离开播放节点                   | 无                                               |
+| `EVENTS.PLAYER.SUBSCRIPTION_READY` | 播放器事件注册完成，可监听 ACTIONS | 无                                               |
 
 #### DOM 类 data
 

--- a/packages/griffith-message/README.md
+++ b/packages/griffith-message/README.md
@@ -98,12 +98,13 @@ Events received from the player
 
 Event sent to the player
 
-| `messageName`                     | Description      | `data`                                                      | Status    |
-| --------------------------------- | ---------------- | ----------------------------------------------------------- | --------- |
-| `ACTIONS.PLAYER.PLAY`             | Play             | `{applyOnFullScreen: boolean}` Applied to full screen video | SUPPORTED |
-| `ACTIONS.PLAYER.PAUSE`            | Pause            | Applied to full screen video                                | SUPPORTED |
-| `ACTIONS.PLAYER.SET_VOLUME`       | Set the volume   | `{volume: number}` Volume value from 0 to 1                 | SUPPORTED |
-| `ACTIONS.PLAYER.ENTER_FULLSCREEN` | Enter fullScreen | null                                                        | SUPPORTED |
-| `ACTIONS.PLAYER.EXIT_FULLSCREEN`  | Exit fullscreen  | null                                                        | SUPPORTED |
-| `ACTIONS.PLAYER.TIME_UPDATE`      | Set current time | `{currentTime: number} Set the currentTime`                 | SUPPORTED |
-| `ACTIONS.PLAYER.SHOW_CONTROLLER`  | Show Controller  | null                                                        | SUPPORTED |
+| `messageName`                      | Description               | `data`                                                      | Status    |
+| ---------------------------------- | ------------------------- | ----------------------------------------------------------- | --------- |
+| `ACTIONS.PLAYER.PLAY`              | Play                      | `{applyOnFullScreen: boolean}` Applied to full screen video | SUPPORTED |
+| `ACTIONS.PLAYER.PAUSE`             | Pause                     | Applied to full screen video                                | SUPPORTED |
+| `ACTIONS.PLAYER.SET_VOLUME`        | Set the volume            | `{volume: number}` Volume value from 0 to 1                 | SUPPORTED |
+| `ACTIONS.PLAYER.ENTER_FULLSCREEN`  | Enter fullScreen          | null                                                        | SUPPORTED |
+| `ACTIONS.PLAYER.EXIT_FULLSCREEN`   | Exit fullscreen           | null                                                        | SUPPORTED |
+| `ACTIONS.PLAYER.TIME_UPDATE`       | Set current time          | `{currentTime: number} Set the currentTime`                 | SUPPORTED |
+| `ACTIONS.PLAYER.SHOW_CONTROLLER`   | Show Controller           | null                                                        | SUPPORTED |
+| `EVENTS.PLAYER.SUBSCRIPTION_READY` | Action subscription ready | null                                                        |

--- a/packages/griffith-message/index.d.ts
+++ b/packages/griffith-message/index.d.ts
@@ -38,6 +38,7 @@ declare const EVENTS: {
     HIDE_CONTROLLER: string
     HOVER_PROGRESS_DOT: string
     LEAVE_PROGRESS_DOT: string
+    SUBSCRIPTION_READY: string
   }
 }
 

--- a/packages/griffith-message/src/constants/events.js
+++ b/packages/griffith-message/src/constants/events.js
@@ -25,4 +25,5 @@ export const PLAYER = {
   HIDE_CONTROLLER: 'event/player/hide-controller',
   HOVER_PROGRESS_DOT: 'event/player/hover-progress-dot',
   LEAVE_PROGRESS_DOT: 'event/player/leave-progress-dot',
+  SUBSCRIPTION_READY: 'event/player/subscription-ready',
 }

--- a/packages/griffith/src/contexts/Message/MessageContext.js
+++ b/packages/griffith/src/contexts/Message/MessageContext.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import EventEmitter from 'eventemitter3'
-import {createMessageHelper} from 'griffith-message'
+import {EVENTS, createMessageHelper} from 'griffith-message'
 
 const EVENT_TYPE = 'event'
 const ACTION_TYPE = 'action'
@@ -47,6 +47,10 @@ export class MessageProvider extends React.PureComponent {
     if (this.props.dispatchRef) {
       this.props.dispatchRef.current = this.externalContextValue.dispatchAction
     }
+
+    Promise.resolve().then(() =>
+      props.onEvent(EVENTS.PLAYER.SUBSCRIPTION_READY)
+    )
   }
 
   componentDidMount() {


### PR DESCRIPTION
# Pull Request Template

## Description

增加一个 event，用以通知外界 actions 注册完毕

## How Has This Been Tested?

- [x] 本地测试

<img width="524" alt="企业微信截图_b4b35703-978f-4cb7-8af0-d209c2993c7e" src="https://user-images.githubusercontent.com/24261011/131662277-cdf04fb5-7fb7-4dc7-8d59-10cf09e55908.png">

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
