### PR TITLE
fix: emit SUBSCRIPTION_READY

### DIFF
--- a/packages/griffith/src/contexts/Message/MessageContext.js
+++ b/packages/griffith/src/contexts/Message/MessageContext.js
@@ -49,7 +49,7 @@ export class MessageProvider extends React.PureComponent {
     }
 
     Promise.resolve().then(() =>
-      props.onEvent(EVENTS.PLAYER.SUBSCRIPTION_READY)
+      this.emitEvent(EVENTS.PLAYER.SUBSCRIPTION_READY)
     )
   }
 


### PR DESCRIPTION
# Pull Request Template

## Description

之前的 onEvent 并没有真正 dispatch cross-window message，应该使用 emitEvent

前置 MR：https://github.com/zhihu/griffith/pull/196

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] 本地测试

![image](https://user-images.githubusercontent.com/24261011/131803196-d5fca5b6-98ac-4c7d-a190-45e9a93adfad.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
