### PR TITLE
ci: run build before test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,7 @@ jobs:
       - name: test
         run: |
           yarn
+          yarn build
           yarn jest --coverage
       - name: report
         uses: coverallsapp/github-action@v1.0.1


### PR DESCRIPTION
修复测试，griffith 包有一些互相依赖，link 指向的是构建后的文件，所以先构建再测试，见：https://github.com/zhihu/griffith/runs/3529866257