### PR TITLE
fix: remove duplicate handleError in Video

### DIFF
--- a/packages/griffith/src/components/Video.js
+++ b/packages/griffith/src/components/Video.js
@@ -221,20 +221,6 @@ class Video extends Component {
     }
   }
 
-  handleError = () => {
-    const {onError} = this.props
-    if (this.isSwitchDefinition) {
-      this.isSwitchDefinition = false
-      this.props.onEvent(
-        EVENTS.PLAYER.CHANGE_QUALITY_FAIL,
-        this.props.currentQuality
-      )
-    }
-    if (onError) {
-      onError(this.root.error)
-    }
-  }
-
   handleDurationChange = () => {
     const {onDurationChange} = this.props
     if (onDurationChange) {
@@ -312,6 +298,14 @@ class Video extends Component {
 
     if (!dontReportPlayFailed) {
       this.props.onEvent(EVENTS.PLAYER.PLAY_FAILED, {currentTime})
+    }
+
+    if (this.isSwitchDefinition) {
+      this.isSwitchDefinition = false
+      this.props.onEvent(
+        EVENTS.PLAYER.CHANGE_QUALITY_FAIL,
+        this.props.currentQuality
+      )
     }
     this.props.onError(error)
   }


### PR DESCRIPTION
文件中错误添加了两个 handleError 方法，删除掉多余的。

TODO：这应该是由 lint 提示出来的。