### PR TITLE
chore: update eslint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,3 @@
-const OFF = 0
-const ERROR = 2
-
 module.exports = {
   // https://eslint.org/docs/user-guide/configuring#specifying-parser-options
   parserOptions: {
@@ -25,9 +22,10 @@ module.exports = {
       files: ['**/*.ts', '**/*.tsx'],
       parser: '@typescript-eslint/parser',
       parserOptions: {
-        project: ['./example/tsconfig.json', './packages/*/tsconfig.json'],
+        project: ['**/tsconfig.json'],
       },
       extends: [
+        'plugin:import/typescript',
         // https://www.npmjs.com/package/@typescript-eslint/eslint-plugin
         'plugin:@typescript-eslint/recommended',
         'plugin:@typescript-eslint/recommended-requiring-type-checking',
@@ -62,13 +60,13 @@ module.exports = {
     'prettier/prettier': ['error', require('./.prettierrc')],
 
     // disable nice-to-have rules for migrate convenience
-    'react/prop-types': OFF,
-    'react/no-find-dom-node': OFF,
-    'react/display-name': OFF,
+    'react/prop-types': 'off',
+    'react/no-find-dom-node': 'off',
+    'react/display-name': 'off',
 
     // recommended rules
-    'prefer-const': ERROR,
-    'no-var': ERROR,
+    'prefer-const': 'error',
+    'no-var': 'error',
 
     // hooks
     'react-hooks/rules-of-hooks': 'error',
@@ -80,16 +78,5 @@ module.exports = {
     react: {
       version: '16',
     },
-    'import/resolver': {
-      node: {
-        extensions: ['.js', '.jsx', '.ts', '.tsx'],
-      },
-    },
-    'import/core-modules': [
-      'griffith',
-      'griffith-mp4',
-      'griffith-utils',
-      'griffith-message',
-    ],
   },
 }

--- a/README-ja.md
+++ b/README-ja.md
@@ -5,6 +5,7 @@
 
 [![License](https://img.shields.io/npm/l/griffith.svg)](https://github.com/zhihu/griffith/blob/master/LICENSE)
 [![npm package](https://img.shields.io/npm/v/griffith/latest.svg)](https://www.npmjs.com/package/griffith)
+![](https://badgen.net/npm/types/griffith)
 [![Coverage Status](https://coveralls.io/repos/github/zhihu/griffith/badge.svg?branch=master)](https://coveralls.io/github/zhihu/griffith?branch=master)
 ![Code style](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/zhihu/griffith/blob/master/CONTRIBUTING.md)

--- a/README-zh-Hans.md
+++ b/README-zh-Hans.md
@@ -5,6 +5,7 @@
 
 [![License](https://img.shields.io/npm/l/griffith.svg)](https://github.com/zhihu/griffith/blob/master/LICENSE)
 [![npm package](https://img.shields.io/npm/v/griffith/latest.svg)](https://www.npmjs.com/package/griffith)
+![](https://badgen.net/npm/types/griffith)
 [![Coverage Status](https://coveralls.io/repos/github/zhihu/griffith/badge.svg?branch=master)](https://coveralls.io/github/zhihu/griffith?branch=master)
 ![Code style](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/zhihu/griffith/blob/master/CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 
 [![License](https://img.shields.io/npm/l/griffith.svg)](https://github.com/zhihu/griffith/blob/master/LICENSE)
 [![npm package](https://img.shields.io/npm/v/griffith/latest.svg)](https://www.npmjs.com/package/griffith)
+![](https://badgen.net/npm/types/griffith)
 [![Coverage Status](https://coveralls.io/repos/github/zhihu/griffith/badge.svg?branch=master)](https://coveralls.io/github/zhihu/griffith?branch=master)
 ![Code style](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/zhihu/griffith/blob/master/CONTRIBUTING.md)

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "zhihu-video-player"
   ],
   "scripts": {
-    "lint": "eslint .",
+    "lint": "eslint --cache . ",
     "test": "jest",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch --notify",


### PR DESCRIPTION
- 此配置自动解决了 tsconfig alias/extensions 问题：
https://github.com/import-js/eslint-plugin-import/blob/main/config/typescript.js
- 额外加了个 types badge
- 默认应当使用 --cache，25s 与 0.7s 的区别