### PR TITLE
fix: 移动端隐藏 controls 后，添加自定义 loading 组件

### DIFF
--- a/packages/griffith/src/components/Player.tsx
+++ b/packages/griffith/src/components/Player.tsx
@@ -624,6 +624,11 @@ class InnerPlayer extends Component<InnerPlayerProps, State> {
             useAutoQuality={useAutoQuality}
           />
         </div>
+        {hideMobileControls && isPlaybackStarted && isLoading && (
+          <div className={css(styles.loader)}>
+            <Loader />
+          </div>
+        )}
         {!hideCover && (
           <div
             className={css(


### PR DESCRIPTION
# Pull Request Template

## Description

隐藏原生video标签的 controls 后，原生 loading 也消失，需添加自定义 loading。使用 Loader组件


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x]  自测通过

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
