### PR TITLE
fix: 通过 hideMobileControls 控制 loading 状态时允许暂停视频

### DIFF
--- a/packages/griffith/src/components/Player.tsx
+++ b/packages/griffith/src/components/Player.tsx
@@ -320,10 +320,11 @@ class InnerPlayer extends Component<InnerPlayerProps, State> {
   }
 
   handlePause = (type: ToggleType = null) => {
+    const {hideMobileControls} = this.props
     this.props.onEvent(EVENTS.REQUEST_PAUSE)
     const {isLoading} = this.state
 
-    if (!isLoading) {
+    if (!isLoading || hideMobileControls) {
       this.setState({
         lastAction: 'pause',
         isPlaying: false,


### PR DESCRIPTION
# Pull Request Template

## Description
目前：触发 pause 事件，视频 loading 时，直接返回，loding 结束，视频会继续播放
通过 hideMobileControls = true 控制 loading 状态时允许暂停视频: loding结束，视频暂停


Fixes # (issue)

## Checklist:

- [x ] 自测通过
