### PR TITLE
fix: 修复controller取不到值的问题

### DIFF
--- a/packages/griffith/src/components/items/PlaybackRateMenuItem.tsx
+++ b/packages/griffith/src/components/items/PlaybackRateMenuItem.tsx
@@ -31,7 +31,7 @@ class PlaybackRateMenuItem extends React.PureComponent<
     return (
       <VideoSourceContext.Consumer>
         {({playbackRates, setCurrentPlaybackRate, currentPlaybackRate}) =>
-          playbackRates.length > 1 && (
+          playbackRates?.length > 1 && (
             <div
               className={css(styles.menuContainer)}
               onMouseEnter={this.handlePlaybackRatePointerEnter}

--- a/packages/griffith/src/components/items/QualityMenuItem.tsx
+++ b/packages/griffith/src/components/items/QualityMenuItem.tsx
@@ -37,7 +37,7 @@ class QualityMenuItem extends React.PureComponent<QualityMenuItemProps, State> {
     return (
       <VideoSourceContext.Consumer>
         {({qualities, setCurrentQuality, currentQuality}) =>
-          qualities.length > 1 && (
+          qualities?.length > 1 && (
             <div
               className={css(styles.menuContainer)}
               onMouseEnter={this.handleQualityPointerEnter}


### PR DESCRIPTION
# Pull Request Template

## Description

当单独使用Controller组件时候会报错找不到倍速数组，因为相关组件是从Context取值，若单独只使用Controller，而没有提供Context就会报错找不到相应的值，因此增加判断没有倍速数组就不展示

Fixes # (issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] 本地自测

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
