### PR TITLE
feat: 添加 noWriteDocTitle，控制是否使用 title 覆盖 document.title

### DIFF
--- a/packages/griffith/README-zh-Hans.md
+++ b/packages/griffith/README-zh-Hans.md
@@ -17,32 +17,33 @@ render(<Player {...props} />)
 
 ### `props`
 
-| 字段                      | 类型                                              | 默认值    | 说明                                       |
-| ------------------------- | ------------------------------------------------- | --------- | ------------------------------------------ |
-| `id`                      | `string`                                          |           | 播放器实例唯一标识                         |
-| `title`                   | `string`                                          |           | 视频标题                                   |
-| `cover`                   | `string`                                          |           | 视频封面图片 URL                           |
-| `duration`                | `number`                                          |           | 初始视频时长。在视频元数据载入后使用实际值 |
-| `sources`                 | `sources`                                         |           | 视频播放数据。具体见下,                    |
-| `defaultQuality`          | `ld \| sd \| hd \| fhd`                           |           | 视频默认播放清晰度                         |
-| `useAutoQuality`          | `boolean`                                         | `false`   | 是否启用自动清晰度功能                     |
-| `standalone`              | `boolean`                                         | `false`   | 是否启用 standalone 模式                   |
-| `onBeforePlay`            | `function`                                        | `void`    | 视频播放之前回调函数                       |
-| `onEvent`                 | `(type: string) => void`                          | `void`    | 公共事件的回调函数                         |
-| `shouldObserveResize`     | `boolean`                                         | `false`   | 是否监听窗口 resize                        |
-| `initialObjectFit`        | `fill \| \contain \| cover \| none \| scale-down` | `contain` | object-fit 参数                            |
-| `useMSE`                  | `boolean`                                         | `false`   | 是否启用 MSE                               |
-| `locale`                  | `en \| ja \| zh-Hans \| zh-Hant`                  | `en`      | 界面语言                                   |
-| `autoplay`                | `boolean`                                         | `false`   | 自动播放                                   |
-| `muted`                   | `boolean`                                         | `false`   | 静音                                       |
-| `disablePictureInPicture` | `boolean`                                         | `false`   | 禁用画中画功能                             |
-| `hiddenPlayButton`        | `boolean`                                         | `false`   | 隐藏播放按钮                               |
-| `hiddenTimeline`          | `boolean`                                         | `false`   | 隐藏进度条                                 |
-| `hiddenTime`              | `boolean`                                         | `false`   | 隐藏播放时间                               |
-| `hiddenQualityMenu`       | `boolean`                                         | `false`   | 隐藏质量选择菜单（如果展示的话）           |
-| `hiddenVolume`            | `boolean`                                         | `false`   | 隐藏音量调节                               |
-| `hiddenFullScreenButton`  | `boolean`                                         | `false`   | 隐藏全屏按钮                               |
-| `progressDots`            | `ProgressDotItem[]`                               | `[]`      | 进度条节点信息                             |
+| 字段                      | 类型                                              | 默认值    | 说明                                                |
+| ------------------------- | ------------------------------------------------- | --------- | --------------------------------------------------- |
+| `id`                      | `string`                                          |           | 播放器实例唯一标识                                  |
+| `title`                   | `string`                                          |           | 视频标题                                            |
+| `cover`                   | `string`                                          |           | 视频封面图片 URL                                    |
+| `duration`                | `number`                                          |           | 初始视频时长。在视频元数据载入后使用实际值          |
+| `sources`                 | `sources`                                         |           | 视频播放数据。具体见下,                             |
+| `defaultQuality`          | `ld \| sd \| hd \| fhd`                           |           | 视频默认播放清晰度                                  |
+| `useAutoQuality`          | `boolean`                                         | `false`   | 是否启用自动清晰度功能                              |
+| `standalone`              | `boolean`                                         | `false`   | 是否启用 standalone 模式                            |
+| `onBeforePlay`            | `function`                                        | `void`    | 视频播放之前回调函数                                |
+| `onEvent`                 | `(type: string) => void`                          | `void`    | 公共事件的回调函数                                  |
+| `shouldObserveResize`     | `boolean`                                         | `false`   | 是否监听窗口 resize                                 |
+| `initialObjectFit`        | `fill \| \contain \| cover \| none \| scale-down` | `contain` | object-fit 参数                                     |
+| `useMSE`                  | `boolean`                                         | `false`   | 是否启用 MSE                                        |
+| `locale`                  | `en \| ja \| zh-Hans \| zh-Hant`                  | `en`      | 界面语言                                            |
+| `autoplay`                | `boolean`                                         | `false`   | 自动播放                                            |
+| `muted`                   | `boolean`                                         | `false`   | 静音                                                |
+| `disablePictureInPicture` | `boolean`                                         | `false`   | 禁用画中画功能                                      |
+| `hiddenPlayButton`        | `boolean`                                         | `false`   | 隐藏播放按钮                                        |
+| `hiddenTimeline`          | `boolean`                                         | `false`   | 隐藏进度条                                          |
+| `hiddenTime`              | `boolean`                                         | `false`   | 隐藏播放时间                                        |
+| `hiddenQualityMenu`       | `boolean`                                         | `false`   | 隐藏质量选择菜单（如果展示的话）                    |
+| `hiddenVolume`            | `boolean`                                         | `false`   | 隐藏音量调节                                        |
+| `hiddenFullScreenButton`  | `boolean`                                         | `false`   | 隐藏全屏按钮                                        |
+| `progressDots`            | `ProgressDotItem[]`                               | `[]`      | 进度条节点信息                                      |
+| `noWriteDocTitle`         | `boolean`                                         | `false`   | standalone 模式，是否使用 title 覆盖 document.title |
 
 `sources` 字段：
 

--- a/packages/griffith/src/components/Player.tsx
+++ b/packages/griffith/src/components/Player.tsx
@@ -74,6 +74,7 @@ type InnerPlayerProps = ProviderOnlyProps & {
   shouldShowPageFullScreenButton?: boolean
   hideMobileControls?: boolean
   hideCover?: boolean
+  noWriteDocTitle?: boolean
 }
 
 // 仅供 Provider 使用的属性
@@ -131,6 +132,7 @@ class InnerPlayer extends Component<InnerPlayerProps, State> {
     progressDots: [],
     hideMobileControls: false,
     hideCover: false,
+    noWriteDocTitle: false,
   }
 
   state = {
@@ -251,9 +253,13 @@ class InnerPlayer extends Component<InnerPlayerProps, State> {
   }
 
   setDocumentTitle = () => {
-    const {title, standalone} = this.props
-
-    if (standalone && typeof title === 'string' && title !== document.title) {
+    const {title, standalone, noWriteDocTitle} = this.props
+    if (
+      standalone &&
+      typeof title === 'string' &&
+      title !== document.title &&
+      !noWriteDocTitle
+    ) {
       document.title = title
     }
   }


### PR DESCRIPTION
## Description
目前现状：
standalone 模式下，接口中的 title 会覆盖 document.title

修改后：
添加 noWriteDocTitle 属性，业务控制是否使用 title 覆盖 document.title，默认值为 true，覆盖。


Fixes # (issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ x ] 自测通过


