### PR TITLE
fix: fix loading state in Player

### DIFF
--- a/packages/griffith/src/components/Player.tsx
+++ b/packages/griffith/src/components/Player.tsx
@@ -370,22 +370,21 @@ class InnerPlayer extends Component<InnerPlayerProps, State> {
   handleVideoError = () => {
     this.setState({
       isPlaying: false,
-      isLoading: false,
     })
   }
 
-  handleVideoDurationChange = (duration: any) => {
+  handleVideoDurationChange = (duration: number) => {
     this.setState({duration})
   }
 
-  handleVideoTimeUpdate = (currentTime: any) => {
+  handleVideoTimeUpdate = (currentTime: number) => {
     const {isLoading} = this.state
     if (isLoading || this.isSeeking) return
     if (this.isSeeking) return
     this.setState({currentTime})
   }
 
-  handleVideoVolumeChange = (volume: any) => {
+  handleVideoVolumeChange = (volume: number) => {
     volume = Math.round(volume * 100) / 100
     this.setState({volume})
     storage.set('@griffith/history-volume', volume)
@@ -407,19 +406,8 @@ class InnerPlayer extends Component<InnerPlayerProps, State> {
     }
   }
 
-  handleVideoWaiting = () => {
-    if (this.showLoaderTimeout !== null) return
-    this.showLoaderTimeout = setTimeout(() => {
-      this.setState({isLoading: true})
-    }, 1000)
-  }
-
-  handleVideoPlaying = () => {
-    if (this.showLoaderTimeout !== null) {
-      clearTimeout(this.showLoaderTimeout)
-      this.showLoaderTimeout = null
-    }
-    this.setState({isLoading: false})
+  handleLoadingChange = (isLoading: boolean) => {
+    this.setState({isLoading})
   }
 
   handleVideoSeeking = () => {
@@ -621,8 +609,7 @@ class InnerPlayer extends Component<InnerPlayerProps, State> {
             onError={this.handleVideoError}
             onDurationChange={this.handleVideoDurationChange}
             onTimeUpdate={this.handleVideoTimeUpdate}
-            onWaiting={this.handleVideoWaiting}
-            onPlaying={this.handleVideoPlaying}
+            onLoadingChange={this.handleLoadingChange}
             onSeeking={this.handleVideoSeeking}
             onSeeked={this.handleVideoSeeked}
             onProgress={this.handleVideoProgress}

--- a/packages/griffith/src/components/VideoWithMessage.tsx
+++ b/packages/griffith/src/components/VideoWithMessage.tsx
@@ -38,6 +38,7 @@ function getMediaEventPayload(event: VideoEvent) {
 export type VideoComponentType = React.ComponentType<NativeVideoProps>
 
 type VideoWithMessageProps = NativeVideoProps & {
+  onNativeEvent?: (event: VideoEvent) => void
   Video: VideoComponentType
 }
 
@@ -56,11 +57,12 @@ const VideoWithMessage = React.forwardRef<
   }, [props])
 
   const newProps = useMemo(() => {
-    const newProps: Partial<NativeVideoProps> = {}
+    const newProps: Partial<VideoWithMessageProps> = {}
     eventMap.forEach(([eventName, key]) => {
       newProps[key] = (event: VideoEvent, ...args: any[]) => {
         emitEvent(eventName, getMediaEventPayload(event))
         const handler = propsRef.current[key] as AnyFunction
+        propsRef.current.onNativeEvent?.(event)
         return handler?.(event, ...args)
       }
     })
@@ -80,7 +82,12 @@ const VideoWithMessage = React.forwardRef<
     [updateVideoSize]
   )
 
-  const {Video, ...otherProps} = props
+  const {
+    Video,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    onNativeEvent,
+    ...otherProps
+  } = props
 
   return (
     <Video


### PR DESCRIPTION
修复 #234 Safari 中拖放滚动条可能造成 UI 卡住，loading 覆盖导致不能交互。

Safari 中 waiting 之后很可能不会触发 playing（即使处于播放中），但 waiting 之后一定会触发 canplay：

| Chrome |  Safari | 
| --- | --- |
| <img width="647" alt="onEvent eventdoncanplay (currentTie" src="https://user-images.githubusercontent.com/105919/150501973-ea314187-3864-4c34-b2c6-55e33760449c.png"> | <img width="638" alt="enEvent eventldomplsy (eurrentTine O, durat ion 182 234, error null)" src="https://user-images.githubusercontent.com/105919/150502035-79d3ec03-aafa-4f32-924b-6a112f3953de.png"> | 
