### PR TITLE
feat: allow use shortcut keys without controller

### DIFF
--- a/packages/griffith-utils/src/__tests__/ua.spec.ts
+++ b/packages/griffith-utils/src/__tests__/ua.spec.ts
@@ -2,14 +2,30 @@
  * @jest-environment jsdom
  */
 
+import ua, {parseUA} from '../ua'
+
 test('ua', () => {
-  Object.defineProperty(window.navigator, 'userAgent', {
-    value:
-      'Mozilla/5.0 (Linux; Android 5.0; SM-G900P Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Mobile Safari/537.36',
-  })
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const {isMobile, isAndroid, isSafari} = require('../ua')
-  expect(isMobile).toBe(true)
-  expect(isAndroid).toBe(true)
-  expect(isSafari).toBe(false)
+  expect(ua).toMatchInlineSnapshot(`
+    Object {
+      "isAndroid": false,
+      "isIE": false,
+      "isMobile": false,
+      "isSafari": false,
+    }
+  `)
+})
+
+test('parse', () => {
+  expect(
+    parseUA(
+      'Mozilla/5.0 (Linux; Android 5.0; SM-G900P Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Mobile Safari/537.36'
+    )
+  ).toMatchInlineSnapshot(`
+    Object {
+      "isAndroid": true,
+      "isIE": false,
+      "isMobile": true,
+      "isSafari": false,
+    }
+  `)
 })

--- a/packages/griffith/src/components/Controller.tsx
+++ b/packages/griffith/src/components/Controller.tsx
@@ -1,8 +1,6 @@
-import React, {useContext, useEffect, useRef, useState} from 'react'
+import React, {useState} from 'react'
 import {css} from 'aphrodite/no-important'
 import clamp from 'lodash/clamp'
-import * as displayIcons from './icons/display/index'
-import * as controllerIcons from './icons/controller/index'
 import {ProgressDot} from '../types'
 import PlayButtonItem from './items/PlayButtonItem'
 import TimelineItem from './items/TimelineItem'
@@ -16,8 +14,6 @@ import PlaybackRateMenuItem from './items/PlaybackRateMenuItem'
 import PageFullScreenButtonItem from './items/PageFullScreenButtonItem'
 import useHandler from '../hooks/useHandler'
 import useBoolean from '../hooks/useBoolean'
-import {useActionToastDispatch} from './ActionToast'
-import VideoSourceContext from '../contexts/VideoSourceContext'
 
 type ControllerProps = {
   standalone?: boolean
@@ -31,11 +27,11 @@ type ControllerProps = {
   isPip: boolean
   onDragStart?: () => void
   onDragEnd?: () => void
-  onPlay?: () => void
-  onPause?: () => void
+  onTogglePlay?: () => void
   onSeek?: (currentTime: number) => void
   onQualityChange?: (...args: any[]) => any
   onVolumeChange?: (volume: number) => void
+  onToggleMuted?: () => void
   onToggleFullScreen?: () => void
   onTogglePageFullScreen?: () => void
   onTogglePip?: (...args: any[]) => void
@@ -89,7 +85,6 @@ function Controller(props: ControllerProps) {
     onTogglePageFullScreen,
     onTogglePip,
     showPip,
-    standalone,
     progressDots,
     hiddenPlayButton,
     hiddenTimeline,
@@ -101,165 +96,23 @@ function Controller(props: ControllerProps) {
     shouldShowPageFullScreenButton,
     onProgressDotHover,
     onProgressDotLeave,
-    onPause,
-    onPlay,
+    onTogglePlay,
     onSeek,
+    onToggleMuted,
     onVolumeChange,
   } = props
-  const {playbackRates, currentPlaybackRate, setCurrentPlaybackRate} =
-    useContext(VideoSourceContext)
-  const actionToastDispatch = useActionToastDispatch()
+
   const [isVolumeHovered, isVolumeHoveredSwitch] = useBoolean()
   const [slideTime, setSlideTime] = useState<number>()
-  const prevVolumeRef = useRef(1)
-
-  const rotatePlaybackRate = (dir: 'next' | 'prev') => {
-    const index = playbackRates?.findIndex(
-      (x) => x.value === currentPlaybackRate.value
-    )
-    if (index >= 0) {
-      const next = playbackRates[index + (dir === 'next' ? 1 : -1)]
-      if (next) {
-        actionToastDispatch({icon: displayIcons.play, label: next.text})
-        setCurrentPlaybackRate(next)
-      }
-    }
-  }
 
   const handleDragMove = useHandler((slideTime: number) => {
     setSlideTime(clamp(slideTime, 0, duration))
   })
 
-  const handleTogglePlay = () => {
-    if (isPlaying) {
-      onPause?.()
-    } else {
-      onPlay?.()
-    }
-  }
-
   const handleSeek = useHandler((currentTime: number) => {
-    currentTime = clamp(currentTime, 0, duration)
-    if (onSeek) {
-      onSeek(currentTime)
-      setSlideTime(void 0)
-    }
+    onSeek?.(clamp(currentTime, 0, duration))
+    setSlideTime(void 0)
   })
-
-  const handleVolumeChange = useHandler((value: number, showToast = false) => {
-    value = clamp(value, 0, 1)
-    if (showToast) {
-      actionToastDispatch({
-        icon: value ? controllerIcons.volume : controllerIcons.muted,
-        label: `${(value * 100).toFixed(0)}%`,
-      })
-    }
-    onVolumeChange?.(value)
-  })
-
-  const handleToggleMuted = useHandler((showToast = false) => {
-    if (volume) {
-      prevVolumeRef.current = volume
-    }
-    handleVolumeChange(volume ? 0 : prevVolumeRef.current, showToast)
-  })
-
-  const handleKeyDown = useHandler((event: KeyboardEvent) => {
-    // 防止冲突，有修饰键按下时不触发自定义热键
-    if (event.altKey || event.ctrlKey || event.metaKey) {
-      return
-    }
-    let handled = true
-
-    switch (event.key) {
-      case ' ':
-      case 'k':
-      case 'K':
-        actionToastDispatch({
-          icon: isPlaying ? displayIcons.pause : displayIcons.play,
-        })
-        handleTogglePlay()
-        break
-
-      case 'Enter':
-      case 'f':
-      case 'F':
-        onToggleFullScreen?.()
-        break
-      case 'Escape':
-        if (isPageFullScreen) {
-          onTogglePageFullScreen?.()
-        }
-        break
-      case 'ArrowLeft':
-        handleSeek(currentTime - 5)
-        break
-
-      case 'ArrowRight':
-        handleSeek(currentTime + 5)
-        break
-
-      case 'j':
-      case 'J':
-        handleSeek(currentTime - 10)
-        break
-
-      case 'l':
-      case 'L':
-        handleSeek(currentTime + 10)
-        break
-      case '0':
-      case '1':
-      case '2':
-      case '3':
-      case '4':
-      case '5':
-      case '6':
-      case '7':
-      case '8':
-      case '9':
-        handleSeek((duration / 10) * Number(event.key))
-        break
-
-      case 'm':
-      case 'M':
-        handleToggleMuted(true)
-        break
-
-      case 'ArrowUp':
-        // 静音状态下调整可能不切换为非静音更好（设置一成临时的，切换后再应用临时状态）
-        handleVolumeChange(volume + 0.05, true)
-        break
-
-      case 'ArrowDown':
-        handleVolumeChange(volume - 0.05, true)
-        break
-
-      case '<':
-        rotatePlaybackRate('prev')
-        break
-
-      case '>':
-        rotatePlaybackRate('next')
-        break
-
-      default:
-        handled = false
-        break
-    }
-    if (handled) {
-      event.preventDefault()
-    }
-  })
-
-  useEffect(() => {
-    if (standalone) {
-      document.addEventListener('keydown', handleKeyDown)
-      return () => {
-        document.removeEventListener('keydown', handleKeyDown)
-      }
-    }
-  }, [handleKeyDown, standalone])
 
   const displayedCurrentTime = slideTime || currentTime
 
@@ -284,7 +137,7 @@ function Controller(props: ControllerProps) {
           {!hiddenPlayButton && (
             <PlayButtonItem
               isPlaying={isPlaying}
-              onClick={() => handleTogglePlay()}
+              onClick={() => onTogglePlay?.()}
             />
           )}
           {hiddenTimeline && <div className={css(styles.timelineHolder)} />}
@@ -318,8 +171,8 @@ function Controller(props: ControllerProps) {
               menuShown={isVolumeHovered}
               onMouseEnter={isVolumeHoveredSwitch.on}
               onMouseLeave={isVolumeHoveredSwitch.off}
-              onToggleMuted={handleToggleMuted}
-              onChange={handleVolumeChange}
+              onToggleMuted={onToggleMuted}
+              onChange={onVolumeChange}
             />
           )}
         </div>

--- a/packages/griffith/src/components/Player.tsx
+++ b/packages/griffith/src/components/Player.tsx
@@ -49,7 +49,6 @@ import useMount from '../hooks/useMount'
 import useHandler from '../hooks/useHandler'
 import usePlayerShortcuts from './usePlayerShortcuts'
 const CONTROLLER_HIDE_DELAY = 3000
-const {isMobile} = ua
 
 // 被 Provider 包装后的属性
 type InnerPlayerProps = {
@@ -273,7 +272,7 @@ const InnerPlayer: React.FC<InnerPlayerProps> = ({
             isLoadingSwitch.on()
           }
           // workaround a bug in IE about replaying a video.
-          if (currentTime !== 0) {
+          if (ua.isIE && currentTime !== 0) {
             handleSeek(0)
           }
         }
@@ -488,7 +487,7 @@ const InnerPlayer: React.FC<InnerPlayerProps> = ({
   const videoDataLoaded = !isLoading || currentTime !== 0
   const renderController = videoDataLoaded && isPlaybackStarted
 
-  const controlsOverlay = !isMobile && (
+  const controlsOverlay = !ua.isMobile && (
     <div className={css(styles.overlay, isNeverPlayed && styles.overlayMask)}>
       {isPlaybackStarted && isLoading && (
         <div className={css(styles.loader)}>
@@ -609,7 +608,7 @@ const InnerPlayer: React.FC<InnerPlayerProps> = ({
       <div className={css(styles.video)}>
         <Video
           ref={videoRef}
-          controls={isMobile && isPlaybackStarted && !hideMobileControls}
+          controls={ua.isMobile && isPlaybackStarted && !hideMobileControls}
           paused={!isPlaying}
           volume={volume}
           loop={loop}
@@ -655,7 +654,7 @@ const InnerPlayer: React.FC<InnerPlayerProps> = ({
             <div
               className={css(
                 styles.coverTime,
-                isMobile && styles.coverTimeMobile
+                ua.isMobile && styles.coverTimeMobile
               )}
             >
               {formatDuration(duration)}

--- a/packages/griffith/src/components/Player.tsx
+++ b/packages/griffith/src/components/Player.tsx
@@ -48,6 +48,7 @@ import useBoolean from '../hooks/useBoolean'
 import useMount from '../hooks/useMount'
 import useHandler from '../hooks/useHandler'
 import usePlayerShortcuts from './usePlayerShortcuts'
+
 const CONTROLLER_HIDE_DELAY = 3000
 
 // 被 Provider 包装后的属性
@@ -138,7 +139,7 @@ const InnerPlayer: React.FC<InnerPlayerProps> = ({
 }) => {
   const {emitEvent, subscribeAction} = useContext(InternalMessageContext)
   const {currentSrc} = useContext(VideoSourceContext)
-  const rootRef = useRef<HTMLDivElement>(null)
+  const [root, setRoot] = useState<HTMLDivElement | null>(null)
   const videoRef = useRef<{
     root: HTMLVideoElement
     seek(currentTime: number): void
@@ -368,7 +369,7 @@ const InnerPlayer: React.FC<InnerPlayerProps> = ({
       const onExit = () => {
         return emitEvent(EVENTS.EXIT_FULLSCREEN)
       }
-      BigScreen?.toggle(rootRef.current!, onEnter, onExit)
+      BigScreen?.toggle(root!, onEnter, onExit)
     }
   })
 
@@ -463,6 +464,7 @@ const InnerPlayer: React.FC<InnerPlayerProps> = ({
   })
 
   usePlayerShortcuts({
+    root,
     prevVolumeRef,
     isPlaying,
     volume,
@@ -603,7 +605,9 @@ const InnerPlayer: React.FC<InnerPlayerProps> = ({
       onMouseDown={handleMouseDown}
       onMouseUp={handleMouseUp}
       onMouseMove={handleShowController}
-      ref={rootRef}
+      ref={setRoot}
+      tabIndex={-1}
+      aria-label={title}
     >
       <div className={css(styles.video)}>
         <Video

--- a/packages/griffith/src/components/usePlayerShortcuts.ts
+++ b/packages/griffith/src/components/usePlayerShortcuts.ts
@@ -1,0 +1,168 @@
+import * as displayIcons from './icons/display/index'
+import * as controllerIcons from './icons/controller/index'
+import {useEffect, useContext} from 'react'
+import clamp from 'lodash/clamp'
+import useHandler from '../hooks/useHandler'
+import {useActionToastDispatch} from './ActionToast'
+import VideoSourceContext from '../contexts/VideoSourceContext'
+
+type Options = {
+  prevVolumeRef: React.MutableRefObject<number>
+  isPlaying: boolean
+  isPageFullScreen: boolean
+  duration: number
+  volume: number
+  currentTime: number
+  standalone?: boolean
+  onVolumeChange: (value: number) => void
+  onTogglePlay: () => void
+  onToggleFullScreen: () => void
+  onTogglePageFullScreen: () => void
+  onSeek: (currentTime: number) => void
+}
+
+const usePlayerShortcuts = ({
+  prevVolumeRef,
+  isPlaying,
+  isPageFullScreen,
+  volume,
+  duration,
+  currentTime,
+  standalone,
+  onVolumeChange,
+  onTogglePlay,
+  onToggleFullScreen,
+  onTogglePageFullScreen,
+  onSeek,
+}: Options) => {
+  const actionToastDispatch = useActionToastDispatch()
+  const {playbackRates, currentPlaybackRate, setCurrentPlaybackRate} =
+    useContext(VideoSourceContext)
+
+  const rotatePlaybackRate = (dir: 'next' | 'prev') => {
+    const index = playbackRates?.findIndex(
+      (x) => x.value === currentPlaybackRate.value
+    )
+    if (index >= 0) {
+      const next = playbackRates[index + (dir === 'next' ? 1 : -1)]
+      if (next) {
+        actionToastDispatch({icon: displayIcons.play, label: next.text})
+        setCurrentPlaybackRate(next)
+      }
+    }
+  }
+
+  const handleVolumeChange = useHandler((value: number, showToast = false) => {
+    value = clamp(value, 0, 1)
+    if (showToast) {
+      actionToastDispatch({
+        icon: value ? controllerIcons.volume : controllerIcons.muted,
+        label: `${(value * 100).toFixed(0)}%`,
+      })
+    }
+    onVolumeChange?.(value)
+  })
+
+  const handleSeek = useHandler((currentTime: number) => {
+    onSeek(clamp(currentTime, 0, duration))
+  })
+
+  const handleKeyDown = useHandler((event: KeyboardEvent) => {
+    // 防止冲突，有修饰键按下时不触发自定义热键
+    if (event.altKey || event.ctrlKey || event.metaKey) {
+      return
+    }
+
+    let handled = true
+    switch (event.key) {
+      case ' ':
+      case 'k':
+      case 'K':
+        actionToastDispatch({
+          icon: isPlaying ? displayIcons.pause : displayIcons.play,
+        })
+        onTogglePlay()
+        break
+
+      case 'Enter':
+      case 'f':
+      case 'F':
+        onToggleFullScreen()
+        break
+      case 'Escape':
+        if (isPageFullScreen) {
+          onTogglePageFullScreen()
+        }
+        break
+      case 'ArrowLeft':
+        handleSeek(currentTime - 5)
+        break
+
+      case 'ArrowRight':
+        handleSeek(currentTime + 5)
+        break
+
+      case 'j':
+      case 'J':
+        handleSeek(currentTime - 10)
+        break
+
+      case 'l':
+      case 'L':
+        handleSeek(currentTime + 10)
+        break
+      case '0':
+      case '1':
+      case '2':
+      case '3':
+      case '4':
+      case '5':
+      case '6':
+      case '7':
+      case '8':
+      case '9':
+        handleSeek((duration / 10) * Number(event.key))
+        break
+
+      case 'm':
+      case 'M':
+        handleVolumeChange(volume ? 0 : prevVolumeRef.current, true)
+        break
+
+      case 'ArrowUp':
+        // 静音状态下调整可能不切换为非静音更好（设置一成临时的，切换后再应用临时状态）
+        handleVolumeChange(volume + 0.05, true)
+        break
+
+      case 'ArrowDown':
+        handleVolumeChange(volume - 0.05, true)
+        break
+
+      case '<':
+        rotatePlaybackRate('prev')
+        break
+
+      case '>':
+        rotatePlaybackRate('next')
+        break
+
+      default:
+        handled = false
+        break
+    }
+    if (handled) {
+      event.preventDefault()
+    }
+  })
+
+  useEffect(() => {
+    if (standalone) {
+      document.addEventListener('keydown', handleKeyDown)
+      return () => {
+        document.removeEventListener('keydown', handleKeyDown)
+      }
+    }
+  }, [handleKeyDown, standalone])
+}
+
+export default usePlayerShortcuts

--- a/packages/griffith/src/components/usePlayerShortcuts.ts
+++ b/packages/griffith/src/components/usePlayerShortcuts.ts
@@ -7,6 +7,7 @@ import {useActionToastDispatch} from './ActionToast'
 import VideoSourceContext from '../contexts/VideoSourceContext'
 
 type Options = {
+  root: HTMLDivElement | null
   prevVolumeRef: React.MutableRefObject<number>
   isPlaying: boolean
   isPageFullScreen: boolean
@@ -22,6 +23,7 @@ type Options = {
 }
 
 const usePlayerShortcuts = ({
+  root,
   prevVolumeRef,
   isPlaying,
   isPageFullScreen,
@@ -156,13 +158,14 @@ const usePlayerShortcuts = ({
   })
 
   useEffect(() => {
-    if (standalone) {
-      document.addEventListener('keydown', handleKeyDown)
+    const el = standalone ? document.body : root
+    if (el) {
+      el.addEventListener('keydown', handleKeyDown)
       return () => {
-        document.removeEventListener('keydown', handleKeyDown)
+        el.removeEventListener('keydown', handleKeyDown)
       }
     }
-  }, [handleKeyDown, standalone])
+  }, [handleKeyDown, root, standalone])
 }
 
 export default usePlayerShortcuts

--- a/packages/griffith/src/utils/parseUA.ts
+++ b/packages/griffith/src/utils/parseUA.ts
@@ -1,4 +1,4 @@
-export function parseUA(userAgent: string) {
+export default function parseUA(userAgent: string) {
   return {
     isIE: /MSIE|Trident/i.test(userAgent),
     isMobile: /iPhone|iPad|iPod|Android/i.test(userAgent),
@@ -6,8 +6,3 @@ export function parseUA(userAgent: string) {
     isSafari: /^((?!chrome|android).)*safari/i.test(userAgent),
   }
 }
-
-export default parseUA(
-  // TODO: 加一个 context 让各处访问更好
-  typeof navigator !== 'undefined' ? navigator.userAgent : ''
-)


### PR DESCRIPTION
- 新增：**允许热键脱离 controller 使用**（迁在 Player 内更合适，但它太长，拆到单独文件里了）—— 例子，在主站的所有视频，还没有播放时没有显示 controller，这时无法使用任意热键，同样播放结束时 controller 也隐藏了，还有不加载 controller 的平板也能外接键盘
- 新增：将 Player 设置为可聚焦元素，这样即使 standalone=false 热键也能工作（对视频的任意操作都会聚焦到上面）—— standalone 看起来是个不恰当的属性，不正交，应当把它的行为拆开
- 修复：ua 中加了 ua 和 typeof 判断：#18 #158