### PR TITLE
fix: do not process shortcut when event is default prevented

### DIFF
--- a/packages/griffith/src/components/Slider.tsx
+++ b/packages/griffith/src/components/Slider.tsx
@@ -144,20 +144,23 @@ class Slider extends Component<SliderProps, State> {
     const {reverse, value, total, step} = this.props
 
     let direction = 0
+    let handled = false
     if (event.key === 'ArrowLeft' || event.key === 'ArrowDown') {
+      handled = true
       direction = -1
-    }
-    if (event.key === 'ArrowRight' || event.key === 'ArrowUp') {
+    } else if (event.key === 'ArrowRight' || event.key === 'ArrowUp') {
+      handled = true
       direction = 1
     }
-    if (reverse) {
-      direction = -direction
-    }
-
-    const result = clamp(value! + step! * direction, 0, total!)
-    if (result !== value) {
+    if (handled) {
       event.preventDefault()
-      this.handleChange(result)
+      if (reverse) {
+        direction = -direction
+      }
+      const result = clamp(value! + step! * direction, 0, total!)
+      if (result !== value) {
+        this.handleChange(result)
+      }
     }
   }
 


### PR DESCRIPTION
预防热键绑定的事件被重复处理：线上 bug 表现，点击进度条（会聚焦到它上面），这时按上/下箭头，进度和音量同时被改变了（不同地方处理了两次）。

不仅是播放器本身，这也能防止与应用其他部分可能存在的冲突。