### PR TITLE
fix: use fixed size for time numbers

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -5,6 +5,11 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Demo</title>
+    <style>
+      body {
+        font-family: -apple-system,BlinkMacSystemFont,Helvetica Neue,PingFang SC,Microsoft YaHei,Source Han Sans SC,Noto Sans CJK SC,WenQuanYi Micro Hei,sans-serif;
+      }
+    </style>
   </head>
   <body>
     <div id="app"></div>

--- a/packages/griffith/src/components/Controller.styles.ts
+++ b/packages/griffith/src/components/Controller.styles.ts
@@ -80,6 +80,7 @@ export default StyleSheet.create({
     fontSize: '0.875em',
     color: 'rgba(255, 255, 255, 0.9)',
     boxSizing: 'content-box',
+    fontVariantNumeric: 'tabular-nums',
   },
 
   labelButton: {

--- a/packages/griffith/src/components/items/__tests__/__snapshots__/CombinedTimeItem.spec.tsx.snap
+++ b/packages/griffith/src/components/items/__tests__/__snapshots__/CombinedTimeItem.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`CombinedTimeItem get CombinedTimeItem component 1`] = `
 <div>
-  <div class="time_i860ms-o_O-fullScreenedTime_1xxtrer">00:06 / 03:02</div>
+  <div class="time_1n8zam0-o_O-fullScreenedTime_1xxtrer">00:06 / 03:02</div>
 </div>
 
 `;


### PR DESCRIPTION
让时间显示不再抖动，案例见：https://www.zhihu.com/zvideo/1437261125772079104 —— 从 1s 开始当前时间就在抖。

[font-variant-numeric](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-numeric) 在不变更字体的情况下，让数字有固定的尺寸 —— 对比 YouTube 视频时间不抖动的原因是因为它使用了定制字体（"YouTube Noto", Roboto）。