### PR TITLE
fix: 修复loading状态下不能暂停的问题

### DIFF
--- a/packages/griffith/src/components/Player.tsx
+++ b/packages/griffith/src/components/Player.tsx
@@ -292,10 +292,7 @@ const InnerPlayer: React.FC<InnerPlayerProps> = ({
 
   const handlePause = () => {
     emitEvent(EVENTS.REQUEST_PAUSE)
-
-    if (!isLoading || hideMobileControls) {
-      isPlayingSwitch.off()
-    }
+    isPlayingSwitch.off()
   }
 
   const handleVideoPlay = () => {


### PR DESCRIPTION
# Pull Request Template

## Description

bug: 视频在loading状态下派发PAUSE action并不能暂停视频

Fixes # (issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] 调整网络弱网，派发PAUAE action,开始loading,loading结束后视频没有暂停

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
