### PR TITLE
fix: 多个播放器使用同一个 Pip 实例问题修复

### DIFF
--- a/packages/griffith/src/utils/pip.ts
+++ b/packages/griffith/src/utils/pip.ts
@@ -62,4 +62,4 @@ class Pip {
   }
 }
 
-export default new Pip()
+export default Pip


### PR DESCRIPTION
## Description
<img width="1062" alt="image" src="https://user-images.githubusercontent.com/20645578/193235865-b983978b-a6ac-48a0-8bf5-fa09b7725dec.png">
多播放器场景会共用一个 Pip 实例，只有第一个播放器能才能正常 init
需要在组件内部执行 new Pip()