### PR TITLE
chore: add video size for events payload

### DIFF
--- a/packages/griffith-message/README-zh-Hans.md
+++ b/packages/griffith-message/README-zh-Hans.md
@@ -97,6 +97,8 @@ dispatchMessage(target: Window, name: ACTIONS, data?: object): void
 | ------------- | --------------------------------------------------------- | -------------------------------------------------- |
 | `currentTime` | `number`                                                  | 当前时间                                           |
 | `duration`    | `number`                                                  | 视频总时长                                         |
+| `videoWidth`  | `number`                                                  | 视频宽度                                           |
+| `videoHeight` | `number`                                                  | 视频高度                                           |
 | `error`       | `{code: number, message: string, name: stirng}` 或 `null` | [`HTMLMediaElement.error`][htmlmediaelement-error] |
 
 [htmlmediaelement-error]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/error 'HTMLMediaElement.error'

--- a/packages/griffith-message/README.md
+++ b/packages/griffith-message/README.md
@@ -97,6 +97,8 @@ Events received from the player
 | ------------- | --------------------------------------------------------- | -------------------------------------------------- |
 | `currentTime` | `number`                                                  | Current time                                       |
 | `duration`    | `number`                                                  | Total video duration                               |
+| `videoWidth`  | `number`                                                  | Video Width                                        |
+| `videoHeight` | `number`                                                  | Video Height                                       |
 | `error`       | `{code: number, message: string, name: stirng}` or `null` | [`HTMLMediaElement.error`][htmlmediaelement-error] |
 
 [htmlmediaelement-error]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/error 'HTMLMediaElement.error'

--- a/packages/griffith-message/src/constants/events.ts
+++ b/packages/griffith-message/src/constants/events.ts
@@ -49,7 +49,7 @@ export const EVENTS = {
 
 export type EVENTS = DOM | PLAYER
 
-type DOMEventParams = {
+export type DOMEventParams = {
   currentTime: number
   duration: number
   videoWidth: number

--- a/packages/griffith-message/src/constants/events.ts
+++ b/packages/griffith-message/src/constants/events.ts
@@ -52,6 +52,8 @@ export type EVENTS = DOM | PLAYER
 type DOMEventParams = {
   currentTime: number
   duration: number
+  videoWidth: number
+  videoHeight: number
   error: {code: number; message: string; name: string} | null
 }
 

--- a/packages/griffith/src/components/VideoWithMessage.tsx
+++ b/packages/griffith/src/components/VideoWithMessage.tsx
@@ -1,5 +1,6 @@
 import React, {useCallback, useContext, useEffect, useMemo, useRef} from 'react'
 import {EVENTS} from 'griffith-message'
+import type {DOMEventParams} from 'griffith-message'
 import {InternalMessageContext} from '../contexts/MessageContext'
 import ObjectFitContext from '../contexts/ObjectFitContext'
 import PositionContext from '../contexts/PositionContext'
@@ -28,7 +29,7 @@ function serializeDOMException(exception?: MediaError | null) {
   return {code, message, name: (exception as any).name}
 }
 
-function getMediaEventPayload(event: VideoEvent) {
+function getMediaEventPayload(event: VideoEvent): DOMEventParams {
   const {currentTime, duration, error, videoWidth, videoHeight} =
     event.currentTarget as HTMLVideoElement
   return {

--- a/packages/griffith/src/components/VideoWithMessage.tsx
+++ b/packages/griffith/src/components/VideoWithMessage.tsx
@@ -29,10 +29,13 @@ function serializeDOMException(exception?: MediaError | null) {
 }
 
 function getMediaEventPayload(event: VideoEvent) {
-  const {currentTime, duration, error} = event.currentTarget as HTMLVideoElement
+  const {currentTime, duration, error, videoWidth, videoHeight} =
+    event.currentTarget as HTMLVideoElement
   return {
     currentTime,
     duration,
+    videoWidth,
+    videoHeight,
     error: serializeDOMException(error),
   }
 }


### PR DESCRIPTION
# Pull Request Template

## Description

Add `videoWidth` and `videoHeight` properties to events payload.

## How Has This Been Tested?

- [x] Run examples locally, listeners can receive these properties.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
