### PR TITLE
fix: does not render 0 when duration and current time both are 0

### DIFF
--- a/packages/griffith/src/components/Player.tsx
+++ b/packages/griffith/src/components/Player.tsx
@@ -679,7 +679,7 @@ const InnerPlayer: React.FC<InnerPlayerProps> = ({
               )}
             </ObjectFitContext.Consumer>
           )}
-          {duration && currentTime === 0 && (
+          {duration !== 0 && currentTime === 0 && (
             <div
               className={css(
                 styles.coverTime,


### PR DESCRIPTION
the expression `0 && 0 === 0 && elem` returns 0, so it renders weird 0 at first few frames and disappears afterwards.