### PR TITLE
feat(griffith): support customPlayer, customHeaders and cover-loaded play gate

### DIFF
--- a/packages/griffith/src/components/Player.tsx
+++ b/packages/griffith/src/components/Player.tsx
@@ -30,6 +30,7 @@ import {
   ProgressValue,
   RealQuality,
   QualityOrder,
+  VideoPlugin,
 } from '../types'
 import formatDuration from '../utils/formatDuration'
 import getBufferedTime from '../utils/getBufferedTime'
@@ -88,6 +89,8 @@ type InnerPlayerProps = {
   layerContent?: React.ReactNode
   crossOrigin?: string | undefined
   customHeaders?: Record<string, string>
+  /** 自定义 MP4 MSE 播放插件，结构同 griffith-mp4 默认导出 */
+  customPlayer?: VideoPlugin
 }
 
 // 仅供 Provider 使用的属性
@@ -147,6 +150,7 @@ const InnerPlayer: React.FC<InnerPlayerProps> = ({
   layerContent,
   crossOrigin,
   customHeaders,
+  customPlayer,
 }) => {
   const {emitEvent, subscribeAction} = useContext(InternalMessageContext)
   const {currentSrc, sources} = useContext(VideoSourceContext)
@@ -668,6 +672,7 @@ const InnerPlayer: React.FC<InnerPlayerProps> = ({
           useMSE={useMSE}
           useAutoQuality={useAutoQuality}
           customHeaders={customHeaders}
+          customPlayer={customPlayer}
         />
       </div>
       {hideMobileControls && isPlaybackStarted && isLoading && (

--- a/packages/griffith/src/components/Player.tsx
+++ b/packages/griffith/src/components/Player.tsx
@@ -87,6 +87,7 @@ type InnerPlayerProps = {
   noWriteDocTitle?: boolean
   layerContent?: React.ReactNode
   crossOrigin?: string | undefined
+  customHeaders?: Record<string, string>
 }
 
 // 仅供 Provider 使用的属性
@@ -145,6 +146,7 @@ const InnerPlayer: React.FC<InnerPlayerProps> = ({
   noWriteDocTitle,
   layerContent,
   crossOrigin,
+  customHeaders,
 }) => {
   const {emitEvent, subscribeAction} = useContext(InternalMessageContext)
   const {currentSrc, sources} = useContext(VideoSourceContext)
@@ -171,6 +173,7 @@ const InnerPlayer: React.FC<InnerPlayerProps> = ({
   const [pressed, pressedSwitch] = useBoolean()
   const [isPageFullScreen, isPageFullScreenSwitch] = useBoolean()
   const [isLoading, isLoadingSwitch] = useBoolean()
+  const [isCoverLoaded, isCoverLoadedSwitch] = useBoolean(!cover)
   const pipRef = useRef<InstanceType<typeof Pip>>()
 
   useEffect(() => {
@@ -178,6 +181,14 @@ const InnerPlayer: React.FC<InnerPlayerProps> = ({
       setDuration(durationProp)
     }
   }, [duration, durationProp])
+
+  useEffect(() => {
+    if (cover) {
+      isCoverLoadedSwitch.off()
+    } else {
+      isCoverLoadedSwitch.on()
+    }
+  }, [cover])
 
   useMount(() => {
     const historyVolume = storage.get('@griffith/history-volume')
@@ -656,6 +667,7 @@ const InnerPlayer: React.FC<InnerPlayerProps> = ({
           onEvent={emitEvent as any}
           useMSE={useMSE}
           useAutoQuality={useAutoQuality}
+          customHeaders={customHeaders}
         />
       </div>
       {hideMobileControls && isPlaybackStarted && isLoading && (
@@ -666,7 +678,7 @@ const InnerPlayer: React.FC<InnerPlayerProps> = ({
       {!hideCover && (
         <div
           className={css(styles.cover, !isPlaybackStarted && styles.coverShown)}
-          onClick={() => handlePlay()}
+          onClick={() => isCoverLoaded && handlePlay()}
         >
           {cover && (
             <ObjectFitContext.Consumer>
@@ -675,9 +687,21 @@ const InnerPlayer: React.FC<InnerPlayerProps> = ({
                   className={css(styles.coverImage)}
                   src={cover}
                   style={{objectFit}}
+                  onLoad={() => isCoverLoadedSwitch.on()}
+                  onError={() => isCoverLoadedSwitch.on()}
+                  ref={(node) => {
+                    if (node && node.complete && node.naturalWidth > 0) {
+                      isCoverLoadedSwitch.on()
+                    }
+                  }}
                 />
               )}
             </ObjectFitContext.Consumer>
+          )}
+          {cover && !isCoverLoaded && (
+            <div className={css(styles.loader)}>
+              <Loader />
+            </div>
           )}
           {duration !== 0 && currentTime === 0 && (
             <div
@@ -690,7 +714,7 @@ const InnerPlayer: React.FC<InnerPlayerProps> = ({
             </div>
           )}
           {/* 只有在第一次未播放时展示播放按钮，播放结束全部展示重播按钮 */}
-          {isNeverPlayed && (
+          {isNeverPlayed && isCoverLoaded && (
             <div className={css(styles.coverAction)}>
               <div className={css(styles.actionButton)}>
                 <Icon icon={displayIcons.play} styles={styles.actionIcon} />

--- a/packages/griffith/src/components/Video.tsx
+++ b/packages/griffith/src/components/Video.tsx
@@ -2,7 +2,13 @@ import React, {Component} from 'react'
 import {css} from 'aphrodite/no-important'
 import {EVENTS} from 'griffith-message'
 import {logger, ua} from 'griffith-utils'
-import {PlaybackRate, Quality, PlaySource, ProgressValue} from '../types'
+import {
+  PlaybackRate,
+  Quality,
+  PlaySource,
+  ProgressValue,
+  VideoPlugin,
+} from '../types'
 import VideoSourceContext from '../contexts/VideoSourceContext'
 import VideoWithMessage, {VideoComponentType} from './VideoWithMessage'
 import selectVideo from './selectVideo'
@@ -36,6 +42,7 @@ type VideoProps = NativeVideoProps & {
   currentPlaybackRate: PlaybackRate
   useAutoQuality?: boolean
   customHeaders?: Record<string, string>
+  customPlayer?: VideoPlugin
 }
 
 class Video extends Component<VideoProps> {
@@ -76,6 +83,7 @@ class Video extends Component<VideoProps> {
       currentPlaybackRate,
       currentQuality,
       onEvent,
+      customPlayer,
     } = this.props
 
     /**
@@ -85,7 +93,7 @@ class Video extends Component<VideoProps> {
     if (prevProps.src && src !== prevProps.src) {
       this.isSwitchDefinition = true
       onEvent(EVENTS.CHANGE_QUALITY_START, currentQuality)
-      const {willHandleSrcChange} = selectVideo(format, useMSE)
+      const {willHandleSrcChange} = selectVideo(format, useMSE, customPlayer)
       // TODO 这一块逻辑需要 Video 自己处理
       if (!willHandleSrcChange) {
         this.safeExecute(() => {
@@ -345,9 +353,10 @@ class Video extends Component<VideoProps> {
       currentQuality,
       crossOrigin,
       customHeaders,
+      customPlayer,
     } = this.props
 
-    const {VideoComponent} = selectVideo(format, useMSE)
+    const {VideoComponent} = selectVideo(format, useMSE, customPlayer)
 
     return (
       <VideoWithMessage

--- a/packages/griffith/src/components/Video.tsx
+++ b/packages/griffith/src/components/Video.tsx
@@ -35,6 +35,7 @@ type VideoProps = NativeVideoProps & {
   onEvent: (name: EVENTS, data?: unknown) => void
   currentPlaybackRate: PlaybackRate
   useAutoQuality?: boolean
+  customHeaders?: Record<string, string>
 }
 
 class Video extends Component<VideoProps> {
@@ -343,6 +344,7 @@ class Video extends Component<VideoProps> {
       sources,
       currentQuality,
       crossOrigin,
+      customHeaders,
     } = this.props
 
     const {VideoComponent} = selectVideo(format, useMSE)
@@ -357,6 +359,7 @@ class Video extends Component<VideoProps> {
         preload="metadata"
         playsInline
         crossOrigin={crossOrigin}
+        customHeaders={customHeaders}
         webkit-playsinline=""
         x-webkit-airplay="deny"
         muted={!volume}

--- a/packages/griffith/src/components/VideoWithMessage.tsx
+++ b/packages/griffith/src/components/VideoWithMessage.tsx
@@ -41,7 +41,9 @@ function getMediaEventPayload(event: VideoEvent): DOMEventParams {
   }
 }
 
-export type VideoComponentType = React.ComponentType<NativeVideoProps>
+export type VideoComponentType = React.ComponentType<
+  NativeVideoProps & {customHeaders?: Record<string, string>}
+>
 
 type VideoWithMessageProps = NativeVideoProps & {
   onNativeEvent?: (event: VideoEvent) => void

--- a/packages/griffith/src/components/selectVideo.ts
+++ b/packages/griffith/src/components/selectVideo.ts
@@ -1,10 +1,15 @@
 import {isHlsNativeSupported, isMSESupported} from 'griffith-utils'
 import GriffithHls from 'griffith-hls'
 import GriffithMp4 from 'griffith-mp4'
+import type {VideoPlugin} from '../types'
 import NormalVideo from './NormalVideo'
 import memoize from 'lodash/memoize'
 
-function selectVideo(format: any, useMSE: any) {
+function selectVideo(
+  format: string,
+  useMSE: boolean | undefined,
+  customPlayer?: VideoPlugin
+) {
   if (
     format === 'm3u8' &&
     GriffithHls?.VideoComponent &&
@@ -13,16 +18,24 @@ function selectVideo(format: any, useMSE: any) {
   ) {
     return GriffithHls
   }
-  if (
-    format === 'mp4' &&
-    GriffithMp4?.VideoComponent &&
-    isMSESupported() &&
-    useMSE
-  ) {
-    return GriffithMp4
+  if (format === 'mp4' && isMSESupported() && useMSE) {
+    if (customPlayer?.VideoComponent) {
+      return {
+        pluginName: customPlayer.pluginName ?? 'custom',
+        VideoComponent: customPlayer.VideoComponent,
+        willHandleSrcChange: customPlayer.willHandleSrcChange ?? true,
+      }
+    }
+    if (GriffithMp4?.VideoComponent) {
+      return GriffithMp4
+    }
   }
   return NormalVideo
 }
 
 // 内部利用了 DOM 推测，避免 render 过程中多次执行
-export default memoize(selectVideo, (...args) => String(args))
+export default memoize(
+  selectVideo,
+  (format, useMSE, customPlayer) =>
+    `${format}-${Boolean(useMSE)}-${customPlayer?.pluginName ?? ''}`
+)

--- a/packages/griffith/src/types.ts
+++ b/packages/griffith/src/types.ts
@@ -4,6 +4,8 @@
  * 定义一些跨许多文件使用的类型
  */
 
+import type {ComponentType} from 'react'
+
 export type RealQuality = 'ld' | 'sd' | 'hd' | 'fhd'
 export type Quality = 'auto' | RealQuality
 export type QualityOrder = 'asc' | 'desc'
@@ -39,4 +41,12 @@ export type ProgressDot = {
 export type ProgressValue = {
   start: number
   end: number
+}
+
+/** 与 griffith-mp4 / griffith-hls 默认导出结构一致，用于 customPlayer 注入 */
+export type VideoPlugin = {
+  pluginName?: string
+  VideoComponent: ComponentType<Record<string, unknown>>
+  /** 切清晰度时是否由插件自行处理 src 变更，默认 true */
+  willHandleSrcChange?: boolean
 }


### PR DESCRIPTION
Pull Request Template
Description
本 PR 为 Griffith Player 扩展三项能力，便于业务侧自定义播放行为与封面交互体验：

1. 封面加载完成前禁止播放（Cover-loaded play gate）
新增 isCoverLoaded 状态，跟踪封面图加载进度
封面未加载完成时：展示 Loader、隐藏播放按钮、禁止点击封面触发播放
支持 onLoad / onError 及浏览器缓存命中（img.complete）场景
cover prop 变化时自动重置加载状态
2. customHeaders 透传
Player 新增 customHeaders?: Record<string, string> prop
经 Player → Video → VideoWithMessage → 底层 VideoComponent 透传
为业务侧在自定义播放插件中注入 HTTP 请求头（如鉴权 Token）预留接口
Note: 当前仅完成 props 链路透传；griffith-hls / griffith-mp4 / NormalVideo 尚未消费该字段。若需默认插件支持，需在对应包中实现（如 HLS 的 xhrSetup）。

3. customPlayer 自定义 MP4 MSE 插件注入
Player 新增 customPlayer?: VideoPlugin prop
新增 VideoPlugin 类型（结构与 griffith-mp4 / griffith-hls 默认导出一致）
selectVideo 在 format === 'mp4' && useMSE 时优先使用 customPlayer，否则回退至 griffith-mp4，再回退至 NormalVideo
切清晰度时的 willHandleSrcChange 逻辑同步支持自定义插件
Motivation: 业务需要替换默认 MP4 MSE 实现（如自定义 fetch / 鉴权），并避免封面未加载时用户误触播放；同时为请求头自定义预留扩展点。

Dependencies: 无新增外部依赖。

Fixes # (issue)

How Has This Been Tested?

 有 cover 时：封面加载中显示 Loader，加载完成后才显示播放按钮并可点击播放

 封面加载失败（onError）时：仍可正常点击播放

 无 cover 时：行为与改动前一致，不受影响

 传入 customPlayer（useMSE={true} + MP4 源）时：使用自定义 VideoComponent 播放

 未传 customPlayer 时：仍使用默认 griffith-mp4 插件

 切换清晰度时：willHandleSrcChange 与自定义插件行为一致

 HLS（m3u8）播放：不受 customPlayer 影响，行为与改动前一致
Test configuration: 本地 example 或业务集成环境，Chrome / Safari，MP4 MSE 与 HLS 场景各验证一次。

